### PR TITLE
Ft/reimplement local suppression

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -169,7 +169,7 @@ pub enum RateLimitDecision {
     Suppressed {
         /// Current suppression rate (0.0 = no suppression, 1.0 = full suppression).
         ///
-        /// Computed as: `1.0 - (perceived_rate / rate_limit)`
+        /// Computed as: `1.0 - (rate_limit / perceived_rate)`
         suppression_factor: f64,
 
         /// Whether this specific call was admitted.

--- a/src/common.rs
+++ b/src/common.rs
@@ -21,6 +21,7 @@ use crate::TrypemaError;
 #[derive(Debug)]
 pub(crate) struct InstantRate {
     pub count: AtomicU64,
+    pub declined: AtomicU64,
     pub timestamp: Instant,
 }
 
@@ -29,6 +30,7 @@ pub(crate) struct RateLimitSeries {
     pub limit: RateLimit,
     pub series: VecDeque<InstantRate>,
     pub total: AtomicU64,
+    pub total_declined: AtomicU64,
 }
 
 impl RateLimitSeries {
@@ -37,11 +39,13 @@ impl RateLimitSeries {
             limit,
             series: VecDeque::new(),
             total: AtomicU64::new(0),
+            total_declined: AtomicU64::new(0),
         }
     }
 }
 
 /// Result of a rate limit admission check.
+///
 ///
 /// Returned by all rate limiting strategies to indicate whether a request should proceed.
 ///

--- a/src/local/absolute_local_rate_limiter.rs
+++ b/src/local/absolute_local_rate_limiter.rs
@@ -136,6 +136,7 @@ impl AbsoluteLocalRateLimiter {
         }
     } // end constructor
 
+    #[cfg(test)]
     pub(crate) fn series(&self) -> &DashMap<String, RateLimitSeries> {
         &self.series
     }

--- a/src/local/absolute_local_rate_limiter.rs
+++ b/src/local/absolute_local_rate_limiter.rs
@@ -1,4 +1,7 @@
-use std::{sync::atomic::Ordering, time::Instant};
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
 
 use dashmap::DashMap;
 
@@ -270,6 +273,7 @@ impl AbsoluteLocalRateLimiter {
             rate_limit_series.series.push_back(InstantRate {
                 count: count.into(),
                 timestamp: Instant::now(),
+                declined: AtomicU64::new(0),
             });
 
             rate_limit_series.total.fetch_add(count, Ordering::Relaxed);

--- a/src/local/local_rate_limiter_provider.rs
+++ b/src/local/local_rate_limiter_provider.rs
@@ -66,8 +66,8 @@ pub struct LocalRateLimiterOptions {
     ///
     /// Defines the absolute maximum rate: `rate_limit × hard_limit_factor`
     ///
-    /// Beyond this limit, requests are unconditionally rejected (not probabilistically
-    /// suppressed). Only relevant for [`SuppressedLocalRateLimiter`].
+    /// Beyond this limit, the suppressed strategy transitions to full suppression
+    /// (`suppression_factor = 1.0`). Only relevant for [`SuppressedLocalRateLimiter`].
     ///
     /// **Typical values:** 1.0-2.0  
     /// **Recommended:** 1.5 (50% burst headroom)  
@@ -92,7 +92,7 @@ pub struct LocalRateLimiterOptions {
 /// # Strategies
 ///
 /// - **Absolute:** Strict sliding-window enforcement
-/// - **Suppressed:** Probabilistic suppression with dual tracking
+/// - **Suppressed:** Probabilistic suppression for graceful degradation
 ///
 /// # Thread Safety
 ///

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -13,7 +13,7 @@
 //! # Strategies
 //!
 //! - [`AbsoluteLocalRateLimiter`]: Strict sliding-window enforcement
-//! - [`SuppressedLocalRateLimiter`]: Probabilistic suppression with dual tracking
+//! - [`SuppressedLocalRateLimiter`]: Probabilistic suppression for graceful degradation
 //!
 //! # When to Use
 //!

--- a/src/local/suppressed_local_rate_limiter.rs
+++ b/src/local/suppressed_local_rate_limiter.rs
@@ -311,6 +311,10 @@ impl SuppressedLocalRateLimiter {
             );
         }
 
+        if suppression_factor > 1f64 {
+            panic!("SuppressedLocalRateLimiter::get_suppression_factor: suppression factor > 1");
+        }
+
         suppression_factor
     }
 

--- a/src/local/suppressed_local_rate_limiter.rs
+++ b/src/local/suppressed_local_rate_limiter.rs
@@ -198,7 +198,11 @@ impl SuppressedLocalRateLimiter {
             unreachable!("SuppressedLocalRateLimiter::inc: key should be in map");
         };
 
-        let suppression_factor = self.get_suppression_factor(key).min(1f64);
+        let suppression_factor = self.get_suppression_factor(key);
+
+        if suppression_factor < 0f64 {
+            unreachable!("SuppressedLocalRateLimiter::inc: suppression_factor < 0");
+        }
 
         let should_allow = if suppression_factor == 1f64 {
             true

--- a/src/local/suppressed_local_rate_limiter.rs
+++ b/src/local/suppressed_local_rate_limiter.rs
@@ -202,6 +202,8 @@ impl SuppressedLocalRateLimiter {
 
         let should_allow = if suppression_factor == 0f64 {
             true
+        } else if suppression_factor == 1f64 {
+            false
         } else {
             random_bool(1f64 - suppression_factor)
         };

--- a/src/local/suppressed_local_rate_limiter.rs
+++ b/src/local/suppressed_local_rate_limiter.rs
@@ -200,7 +200,7 @@ impl SuppressedLocalRateLimiter {
 
         let suppression_factor = self.get_suppression_factor(key);
 
-        let should_allow = if suppression_factor == 1f64 {
+        let should_allow = if suppression_factor == 0f64 {
             true
         } else {
             random_bool(1f64 - suppression_factor)
@@ -241,7 +241,7 @@ impl SuppressedLocalRateLimiter {
         }
 
         match suppression_factor {
-            1f64 => RateLimitDecision::Allowed,
+            0f64 => RateLimitDecision::Allowed,
             _ => RateLimitDecision::Suppressed {
                 suppression_factor,
                 is_allowed: should_allow,

--- a/src/tests/test_absolute_local_rate_limiter.rs
+++ b/src/tests/test_absolute_local_rate_limiter.rs
@@ -31,6 +31,7 @@ fn insert_series(
         .iter()
         .map(|(count, ms_ago)| InstantRate {
             count: AtomicU64::new(*count),
+            declined: AtomicU64::new(0),
             timestamp: Instant::now() - Duration::from_millis(*ms_ago),
         })
         .collect::<VecDeque<_>>();
@@ -41,6 +42,7 @@ fn insert_series(
             limit,
             series,
             total: AtomicU64::new(total),
+            total_declined: AtomicU64::new(0),
         },
     );
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Reimplemented local suppression strategy to track declined calls directly

- Removed dual-limiter architecture; now uses single series with declined counters

- Added validation to panic on invalid suppression factors (< 0 or > 1)

- Optimized suppression factor computation to avoid RNG calls at boundaries (0.0 and 1.0)

- Updated documentation and tests to reflect new implementation semantics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old: Dual Limiters<br/>accepted + observed"] -->|Remove| B["New: Single Series<br/>with declined counters"]
  B -->|Track| C["total: all calls<br/>declined: denied calls"]
  C -->|Compute| D["suppression_factor<br/>1.0 - rate_limit/perceived_rate"]
  D -->|Validate| E["Panic if &lt; 0 or &gt; 1"]
  E -->|Optimize| F["Skip RNG at<br/>boundaries 0.0, 1.0"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.rs</strong><dd><code>Add declined call tracking to rate limit structures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common.rs

<ul><li>Added <code>declined: AtomicU64</code> field to <code>InstantRate</code> struct to track denied <br>calls<br> <li> Added <code>total_declined: AtomicU64</code> field to <code>RateLimitSeries</code> to track <br>total declined calls<br> <li> Updated <code>RateLimitSeries::new()</code> to initialize <code>total_declined</code> to 0<br> <li> Fixed suppression factor formula documentation from <code>1.0 - </code><br><code>(perceived_rate / rate_limit)</code> to <code>1.0 - (rate_limit / perceived_rate)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-e24518d69b6357926bce35868225330c1992a4029b521c0112b4ec8523ddc31c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>absolute_local_rate_limiter.rs</strong><dd><code>Add test-only visibility and declined field initialization</code></dd></summary>
<hr>

src/local/absolute_local_rate_limiter.rs

<ul><li>Added <code>AtomicU64</code> import for declined field initialization<br> <li> Added <code>#[cfg(test)]</code> attribute to <code>series()</code> method<br> <li> Updated <code>InstantRate</code> construction to initialize <code>declined</code> field with 0</ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-644be5f103f48cf6263bdd1370d70caccec6be3c0959e1a5d3b72a75ee9fbfe1">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>suppressed_local_rate_limiter.rs</strong><dd><code>Reimplement suppression with single series and declined tracking</code></dd></summary>
<hr>

src/local/suppressed_local_rate_limiter.rs

<ul><li>Removed <code>accepted_limiter</code> and <code>observed_limiter</code> fields; replaced with <br>direct <code>series: DashMap<String, RateLimitSeries></code><br> <li> Restructured struct to store <code>window_size_seconds</code>, <code>rate_group_size_ms</code>, <br><code>series</code>, <code>hard_limit_factor</code>, <code>suppression_factor_cache_ms</code>, and <br><code>suppression_factors</code><br> <li> Rewrote <code>inc_with_rng()</code> to directly track calls in series with declined <br>counters instead of delegating to two separate limiters<br> <li> Added <code>remove_expired_buckets()</code> method to clean up old time-window <br>entries<br> <li> Added validation in <code>get_suppression_factor()</code> to panic if suppression <br>factor is < 0 or > 1<br> <li> Optimized <code>inc_with_rng()</code> to skip RNG calls when suppression_factor is <br>exactly 0.0 or 1.0<br> <li> Simplified <code>calculate_suppression_factor()</code> to work with single series <br>and use observed total directly<br> <li> Updated <code>cleanup()</code> to manage series retention based on timestamp <br>staleness<br> <li> Removed <code>accepted_limiter()</code> and <code>observed_limiter()</code> test accessors<br> <li> Completely rewrote algorithm documentation with new three-regime <br>explanation</ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-31c438b3c13bcb698fbdd50008a2a7f1acf23348ada08600f185e6fc853b7758">+160/-200</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local_rate_limiter_provider.rs</strong><dd><code>Update documentation for suppression strategy semantics</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/local/local_rate_limiter_provider.rs

<ul><li>Updated documentation for <code>hard_limit_factor</code> to clarify it transitions <br>to full suppression rather than unconditional rejection<br> <li> Changed suppressed strategy description from "dual tracking" to <br>"graceful degradation"<br> <li> Added <code>suppression_factor_cache_ms</code> to README table</ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-d164524886546cc2aa6969d98102a494d0301fbd507b8da806e8dcfd5fd14683">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update module documentation for suppressed strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/local/mod.rs

<ul><li>Updated module-level documentation to describe suppressed strategy as <br>"graceful degradation" instead of "dual tracking"</ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-3b8b7622319a6602e46727f46d26b3135723bd7b9d02d70e37f55458069d641e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README for new suppression implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added <code>suppression_factor_cache_ms</code> row to configuration options table<br> <li> Updated suppressed strategy documentation to clarify "Semantics" <br>instead of "Dual tracking"<br> <li> Changed behavior description to indicate local provider returns <br><code>Suppressed { is_allowed: false, suppression_factor: 1.0 }</code> at hard <br>limit instead of <code>Rejected</code><br> <li> Fixed suppression factor formula from <code>perceived_rate / rate_limit</code> to <br><code>rate_limit / perceived_rate</code><br> <li> Removed reference to non-existent <code>docs/</code> directory</ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_absolute_local_rate_limiter.rs</strong><dd><code>Update test helpers for declined field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_absolute_local_rate_limiter.rs

<ul><li>Updated <code>insert_series()</code> helper to initialize <code>declined: </code><br><code>AtomicU64::new(0)</code> for each <code>InstantRate</code><br> <li> Updated test series insertion to initialize <code>total_declined: </code><br><code>AtomicU64::new(0)</code> in <code>RateLimitSeries</code></ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-ba327ec8adcd72b14d3cbf61f13eb91e6896bac99e325cf1fe06922abce22b8c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_suppressed_local_rate_limiter.rs</strong><dd><code>Rewrite tests for single-series suppression implementation</code></dd></summary>
<hr>

src/tests/test_suppressed_local_rate_limiter.rs

<ul><li>Removed imports for <code>VecDeque</code>, <code>AtomicU64</code>, <code>Ordering</code>, and test helper <br>functions for dual-limiter access<br> <li> Removed <code>total_for_key()</code> and <code>insert_series()</code> helper functions (no <br>longer needed)<br> <li> Added <code>limiter_with_cache_ms()</code> helper for tests requiring custom cache <br>duration<br> <li> Rewrote all suppression factor calculation tests to use <br><code>test_set_suppression_factor()</code> and <code>get_suppression_factor()</code> directly<br> <li> Changed test expectations to allow both <code>Rejected</code> and <code>Suppressed</code> <br>returns for hard-limit scenarios<br> <li> Added panic tests for negative and > 1.0 suppression factors<br> <li> Replaced tests checking dual-limiter state with tests verifying <br>suppression behavior contracts<br> <li> Added comprehensive property-based test <br><code>suppression_property_values_do_not_panic_and_follow_basic_contract()</code> <br>covering all suppression factor ranges<br> <li> Updated cleanup tests to verify series retention based on staleness <br>rather than dual-limiter state</ul>


</details>


  </td>
  <td><a href="https://github.com/dev-davexoyinbo/trypema/pull/7/files#diff-a19adfa2bb6a7ee0663c91385fc15ab9a8f388f32404484ce7c13c431e7d81c9">+227/-169</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

