### PR TITLE
Ft/v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ dependencies = [
  "futures",
  "rand 0.10.0",
  "redis",
+ "regex",
  "smol",
  "strum",
  "strum_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,19 +1762,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tracing = "0.1.44"
 tokio = { version = "1.51", optional = true, default-features = false }
 smol = { version = "2.0.2", optional = true }
 ahash = "0.8.12"
+regex = { version = "1", optional = true }
 futures = { version = "0.3.32", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 
@@ -66,6 +67,7 @@ redis-tokio = [
   "tokio/rt-multi-thread",
   "dep:async-trait",
   "dep:futures",
+  "dep:regex",
 ]
 redis-smol = [
   "redis",
@@ -77,6 +79,7 @@ redis-smol = [
   "tokio/sync",
   "dep:async-trait",
   "dep:futures",
+  "dep:regex",
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ redis-tokio = [
   "tokio/sync",
   "tokio/rt",
   "tokio/time",
-  "tokio/macros",
   "tokio/rt-multi-thread",
   "dep:async-trait",
   "dep:futures",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Trypema Rate Limiter
+
 [![Crates.io](https://img.shields.io/crates/v/trypema.svg)](https://crates.io/crates/trypema)
 [![Documentation](https://docs.rs/trypema/badge.svg)](https://docs.rs/trypema)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -21,764 +22,304 @@ a rate limiter is a narrow gate that controls the flow of requests into a system
 
 ## Overview
 
-Trypema is a Rust rate limiting library that supports both in-process and Redis-backed
-distributed enforcement. It provides two complementary strategies — strict enforcement and
-probabilistic suppression — across three provider backends.
+Trypema is a sliding-window rate limiting crate with:
 
-**Documentation:** <https://trypema.davidoyinbo.com>
+- **Local** in-memory limiting for single-process workloads
+- **Redis** best-effort distributed limiting with atomic Lua scripts
+- **Hybrid** best-effort distributed limiting with a local fast path and periodic Redis sync
 
-**Benchmark comparisons:**
+Each provider offers:
 
-- Local provider: <https://trypema.davidoyinbo.com/benchmarks/benchmark-results/local-benchmark-comparison>
-- Redis provider: <https://trypema.davidoyinbo.com/benchmarks/benchmark-results/redis-benchmark-comparison>
+- **Absolute** deterministic allow/reject decisions
+- **Suppressed** probabilistic degradation near or above the target rate
 
-### Providers
+## Picking a Provider
 
-Trypema organises rate limiting into three **providers**, each suited to different deployment
-scenarios:
+| Provider   | Best for                                   | Trade-off                                        |
+| ---------- | ------------------------------------------ | ------------------------------------------------ |
+| **Local**  | single-process services, jobs, CLIs        | not shared across processes                      |
+| **Redis**  | shared limits across processes or machines | every check performs Redis I/O                   |
+| **Hybrid** | high-throughput distributed request paths  | state can lag behind Redis by `sync_interval_ms` |
 
-| Provider   | Backend                               | Latency                     | Consistency               | Use Case                         |
-| ---------- | ------------------------------------- | --------------------------- | ------------------------- | -------------------------------- |
-| **Local**  | In-process `DashMap` + atomics        | Sub-microsecond             | Single-process only       | CLI tools, single-server APIs    |
-| **Redis**  | Redis 7.2+ via Lua scripts            | Network round-trip per call | Distributed (best-effort) | Multi-process / multi-server     |
-| **Hybrid** | Local fast-path + periodic Redis sync | Sub-microsecond (fast-path) | Distributed with sync lag | High-throughput distributed APIs |
+Redis and hybrid providers require Redis 7.2+ and exactly one runtime feature: `redis-tokio` or
+`redis-smol`.
 
-### Strategies
+## Installation
 
-Each provider exposes two **strategies** that determine how rate limit decisions are made:
+Local-only:
 
-- **Absolute** — A deterministic sliding-window limiter. Requests under the window capacity
-  are allowed; requests over it are immediately rejected. Simple and predictable.
+```toml
+[dependencies]
+trypema = "1"
+```
 
-- **Suppressed** — A probabilistic strategy inspired by
-  [Ably's distributed rate limiting approach](https://ably.com/blog/distributed-rate-limiting-scale-your-platform).
-  Instead of a hard cutoff, it computes a _suppression factor_ and probabilistically denies a
-  fraction of requests proportional to how far over the limit the key is. This produces smooth
-  degradation rather than a cliff-edge rejection.
+Redis with Tokio:
 
-### Key Capabilities
+```toml
+[dependencies]
+trypema = { version = "1", features = ["redis-tokio"] }
+```
 
-- Non-integer rate limits (e.g., `0.5` or `5.5` requests per second)
-- Sliding time windows for smooth burst handling (no fixed-window boundary resets)
-- Configurable bucket coalescing to trade timing precision for lower overhead
-- Automatic background cleanup of stale keys (with `Weak` reference — no leak risk)
-- Best-effort rejection metadata (`retry_after_ms`, `remaining_after_waiting`) for backoff hints
-- Feature-flag driven compilation — zero Redis dependencies when you only need local limiting
+Redis with Smol:
 
-### Non-Goals
-
-This crate is **not** designed for:
-
-- **Strictly linearizable admission control.** Concurrent requests may temporarily overshoot
-  limits. This is by design: the library prioritises throughput over strict serialisation.
-- **Strong consistency in distributed scenarios.** Redis-backed limiting is best-effort;
-  multiple clients can exceed limits simultaneously during network partitions or high concurrency.
-- **Built-in retry logic.** Retry/backoff policies are application-specific and left to the caller.
+```toml
+[dependencies]
+trypema = { version = "1", features = ["redis-smol"] }
+```
 
 ## Quick Start
 
-### Local Provider (In-Process)
+### Common Types
 
-Use the local provider when you need single-process rate limiting with no external dependencies.
+`RateLimit` is the per-second limit value used by all providers. `RedisKey` is the validated key
+type required by the Redis and hybrid providers. `RateLimitDecision` is the result returned by
+`inc()` and `is_allowed()`, and `RateLimiter` is the top-level entry point used throughout the
+examples.
 
-```toml
-[dependencies]
-trypema = "1.0"
+```rust,no_run
+use trypema::RateLimit;
+use trypema::redis::RedisKey;
+
+let _rate_a = RateLimit::new(5.0).unwrap();
+let _rate_b = RateLimit::try_from(5.0).unwrap();
+let _rate_c = RateLimit::new_or_panic(5.0);
+
+let _key_a = RedisKey::new("user_123".to_string()).unwrap();
+let _key_b = RedisKey::try_from("user_123".to_string()).unwrap();
+let _key_c = RedisKey::new_or_panic("user_123".to_string());
+```
+
+### Create a `RateLimiter`
+
+These examples show the local-only and Redis-enabled builder paths.
+
+```rust
+use trypema::{RateLimit, RateLimitDecision, RateLimiterBuilder};
+
+let rl = RateLimiterBuilder::default()
+    // Optional: override the sliding window size.
+    .window_size_seconds(60)
+    // Optional: override bucket coalescing.
+    .rate_group_size_ms(10)
+    // Optional: tune suppressed-mode headroom.
+    .hard_limit_factor(1.5)
+    // Optional: tune cleanup cadence.
+    .cleanup_interval_ms(15_000)
+    .build()
+    .unwrap();
+
+let rate = RateLimit::try_from(5.0).unwrap();
+
+assert!(matches!(
+    rl.local().absolute().inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
+```
+
+```rust
+use trypema::{RateLimit, RateLimitDecision, RateLimiter};
+
+let rl = RateLimiter::builder().build().unwrap();
+let rate = RateLimit::try_from(5.0).unwrap();
+
+assert!(matches!(
+    rl.local().absolute().inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
 ```
 
 ```rust,no_run
+use trypema::{RateLimit, RateLimitDecision, RateLimiter};
+use trypema::redis::RedisKey;
+
+async fn example() -> Result<(), trypema::TrypemaError> {
+    let url = std::env::var("REDIS_URL")
+        .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+    let connection_manager = redis::Client::open(url)?
+        .get_connection_manager()
+        .await?;
+
+    let rl = RateLimiter::builder(connection_manager)
+        // Optional: override the sliding window size.
+        .window_size_seconds(60)
+        // Optional: override bucket coalescing.
+        .rate_group_size_ms(10)
+        // Optional: tune suppressed-mode headroom.
+        .hard_limit_factor(1.5)
+        // Optional: only available with `redis-tokio` or `redis-smol`.
+        .redis_prefix(RedisKey::new_or_panic("docs".to_string()))
+        // Optional: only available with `redis-tokio` or `redis-smol`.
+        .sync_interval_ms(10)
+        .build()?;
+
+    let key = RedisKey::try_from("user_123".to_string())?;
+    let rate = RateLimit::try_from(5.0).unwrap();
+
+    assert!(matches!(
+        rl.redis().absolute().inc(&key, &rate, 1).await?,
+        RateLimitDecision::Allowed
+    ));
+
+    Ok(())
+}
+```
+
+```rust
 use std::sync::Arc;
 
 use trypema::{
-    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions,
-    SuppressionFactorCacheMs, WindowSizeSeconds,
+    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter,
+    RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds,
 };
 use trypema::local::LocalRateLimiterOptions;
 
-let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-let hard_limit_factor = HardLimitFactor::default();
-let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-
 let options = RateLimiterOptions {
     local: LocalRateLimiterOptions {
-        window_size_seconds,
-        rate_group_size_ms,
-        hard_limit_factor,
-        suppression_factor_cache_ms,
+        window_size_seconds: WindowSizeSeconds::new_or_panic(60),
+        rate_group_size_ms: RateGroupSizeMs::new_or_panic(10),
+        hard_limit_factor: HardLimitFactor::new_or_panic(1.5),
+        suppression_factor_cache_ms: SuppressionFactorCacheMs::new_or_panic(100),
     },
 };
 
 let rl = Arc::new(RateLimiter::new(options));
-
-// Start background cleanup to remove stale keys.
-// Idempotent: calling this multiple times is a no-op while running.
 rl.run_cleanup_loop();
 
-// Define a rate limit of 5 requests per second.
-// With a 60-second window, the window capacity is 60 × 5 = 300 requests.
-let key = "user_123";
-let rate_limit = RateLimit::try_from(5.0).unwrap();
+let rate = RateLimit::try_from(5.0).unwrap();
 
-// --- Absolute strategy: deterministic sliding-window enforcement ---
-match rl.local().absolute().inc(key, &rate_limit, 1) {
-    RateLimitDecision::Allowed => {
-        // Under capacity — proceed with the request.
-    }
-    RateLimitDecision::Rejected { retry_after_ms, .. } => {
-        // Over capacity — reject and suggest the client retry later.
-        // `retry_after_ms` is a best-effort hint based on the oldest bucket's TTL.
-        let _ = retry_after_ms;
-    }
-    RateLimitDecision::Suppressed { .. } => {
-        unreachable!("absolute strategy never returns Suppressed");
-    }
-}
-
-// --- Suppressed strategy: probabilistic suppression near/over the limit ---
-//
-// You can query the suppression factor at any time for metrics/debugging.
-let sf = rl.local().suppressed().get_suppression_factor(key);
-let _ = sf;
-
-match rl.local().suppressed().inc(key, &rate_limit, 1) {
-    RateLimitDecision::Allowed => {
-        // Below capacity — no suppression active, proceed normally.
-    }
-    RateLimitDecision::Suppressed {
-        is_allowed: true,
-        suppression_factor,
-    } => {
-        // At/above capacity — suppression is active, but this particular request
-        // was probabilistically allowed. Proceed, but consider logging the factor.
-        let _ = suppression_factor;
-    }
-    RateLimitDecision::Suppressed {
-        is_allowed: false,
-        suppression_factor,
-    } => {
-        // At/above capacity — this request was probabilistically denied.
-        // Do NOT proceed. When over the hard limit, suppression_factor will be 1.0.
-        let _ = suppression_factor;
-    }
-    RateLimitDecision::Rejected { .. } => {
-        unreachable!("local suppressed strategy never returns Rejected");
-    }
-}
+assert!(matches!(
+    rl.local().absolute().inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
 ```
 
-### Redis Provider (Distributed)
+`build()` starts the cleanup loop automatically. `RateLimiter::new(...)` does not, so call
+`run_cleanup_loop()` yourself when you want background cleanup of stale keys.
 
-Use the Redis provider for distributed rate limiting across multiple processes or servers.
-Every `inc()` and `is_allowed()` call executes an atomic Lua script against Redis.
+### Local Read-Only Check
 
-**Requirements:**
+```rust
+use trypema::{RateLimit, RateLimitDecision, RateLimiter};
 
-- Redis >= 7.2
-- Tokio or Smol async runtime
+let rl = RateLimiter::builder().build().unwrap();
+let limiter = rl.local().absolute();
+let rate = RateLimit::try_from(5.0).unwrap();
 
-```toml
-[dependencies]
-trypema = { version = "1.0", features = ["redis-tokio"] }
-redis = { version = "1", default-features = false, features = ["aio", "tokio-comp", "connection-manager"] }
-tokio = { version = "1", features = ["full"] }
+assert!(matches!(limiter.is_allowed("user_123"), RateLimitDecision::Allowed));
+assert!(matches!(
+    limiter.inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
 ```
+
+### Read Current Suppression State
+
+```rust
+use trypema::RateLimiter;
+
+let rl = RateLimiter::builder().build().unwrap();
+
+let sf = rl.local().suppressed().get_suppression_factor("user_123");
+assert_eq!(sf, 0.0);
+```
+
+### Redis Absolute
 
 ```rust,no_run
-use std::sync::Arc;
+use trypema::{RateLimit, RateLimitDecision, RateLimiter};
+use trypema::redis::RedisKey;
 
-use trypema::{
-    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions,
-    SuppressionFactorCacheMs, WindowSizeSeconds,
-};
-use trypema::hybrid::SyncIntervalMs;
-use trypema::local::LocalRateLimiterOptions;
-use trypema::redis::{RedisKey, RedisRateLimiterOptions};
+async fn example() -> Result<(), trypema::TrypemaError> {
+    let url = std::env::var("REDIS_URL")
+        .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+    let connection_manager = redis::Client::open(url)?
+        .get_connection_manager()
+        .await?;
 
-#[tokio::main]
-async fn main() -> Result<(), trypema::TrypemaError> {
-    // Create a Redis connection manager (handles pooling and reconnection).
-    let client = redis::Client::open("redis://127.0.0.1:6379/").unwrap();
-    let connection_manager = client.get_connection_manager().await.unwrap();
-
-    let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    let hard_limit_factor = HardLimitFactor::default();
-    let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    let sync_interval_ms = SyncIntervalMs::default();
-
-    let rl = Arc::new(RateLimiter::new(RateLimiterOptions {
-        local: LocalRateLimiterOptions {
-            window_size_seconds,
-            rate_group_size_ms,
-            hard_limit_factor,
-            suppression_factor_cache_ms,
-        },
-        redis: RedisRateLimiterOptions {
-            connection_manager,
-            prefix: None, // Defaults to "trypema"
-            window_size_seconds,
-            rate_group_size_ms,
-            hard_limit_factor,
-            suppression_factor_cache_ms,
-            sync_interval_ms,
-        },
-    }));
-
-    rl.run_cleanup_loop();
-
-    let rate_limit = RateLimit::try_from(5.0).unwrap();
-    let key = RedisKey::try_from("user_123".to_string()).unwrap();
-
-    // --- Absolute strategy ---
-    match rl.redis().absolute().inc(&key, &rate_limit, 1).await? {
-        RateLimitDecision::Allowed => {
-            // Request allowed, proceed.
-        }
-        RateLimitDecision::Rejected { retry_after_ms, .. } => {
-            // Rejected — send HTTP 429 with Retry-After header.
-            let _ = retry_after_ms;
-        }
-        RateLimitDecision::Suppressed { .. } => {
-            unreachable!("absolute strategy never returns Suppressed");
-        }
-    }
-
-    // --- Suppressed strategy ---
-    let sf = rl.redis().suppressed().get_suppression_factor(&key).await?;
-    let _ = sf;
-
-    match rl.redis().suppressed().inc(&key, &rate_limit, 1).await? {
-        RateLimitDecision::Allowed => {
-            // Below capacity, proceed.
-        }
-        RateLimitDecision::Suppressed {
-            is_allowed: true,
-            suppression_factor,
-        } => {
-            // Suppression active but this request admitted.
-            let _ = suppression_factor;
-        }
-        RateLimitDecision::Suppressed {
-            is_allowed: false,
-            suppression_factor,
-        } => {
-            // Suppressed — do not proceed. When over the hard limit, suppression_factor is 1.0.
-            let _ = suppression_factor;
-        }
-        RateLimitDecision::Rejected { .. } => {
-            unreachable!("suppressed strategy never returns Rejected");
-        }
-    }
-
-    Ok(())
-}
-```
-
-### Hybrid Provider (Local Fast-Path + Redis Sync)
-
-The hybrid provider combines the low latency of in-process state with the distributed
-consistency of Redis. It maintains a local counter per key and periodically flushes
-accumulated increments to Redis in batches. Between flushes, admission decisions are
-served from local state without any Redis I/O.
-
-This is the recommended provider for high-throughput distributed APIs where per-request
-Redis round-trips are too expensive.
-
-**Trade-off:** Admission decisions reflect Redis state with up to `sync_interval_ms` of lag.
-
-```rust,no_run
-use std::sync::Arc;
-
-use trypema::{
-    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimiter, RateLimiterOptions,
-    SuppressionFactorCacheMs, WindowSizeSeconds,
-};
-use trypema::hybrid::SyncIntervalMs;
-use trypema::local::LocalRateLimiterOptions;
-use trypema::redis::{RedisKey, RedisRateLimiterOptions};
-
-#[tokio::main]
-async fn main() -> Result<(), trypema::TrypemaError> {
-    let client = redis::Client::open("redis://127.0.0.1:6379/").unwrap();
-    let connection_manager = client.get_connection_manager().await.unwrap();
-
-    let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    let hard_limit_factor = HardLimitFactor::default();
-    let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    let sync_interval_ms = SyncIntervalMs::default();
-
-    let rl = Arc::new(RateLimiter::new(RateLimiterOptions {
-        local: LocalRateLimiterOptions {
-            window_size_seconds,
-            rate_group_size_ms,
-            hard_limit_factor,
-            suppression_factor_cache_ms,
-        },
-        redis: RedisRateLimiterOptions {
-            connection_manager,
-            prefix: None,
-            window_size_seconds,
-            rate_group_size_ms,
-            hard_limit_factor,
-            suppression_factor_cache_ms,
-            sync_interval_ms,
-        },
-    }));
-
+    let rl = RateLimiter::builder(connection_manager).build()?;
     let key = RedisKey::try_from("user_123".to_string())?;
-    let rate = RateLimit::try_from(10.0)?;
+    let rate = RateLimit::try_from(5.0).unwrap();
 
-    // Absolute: same API as the Redis provider, served from local state.
-    let _decision = rl.hybrid().absolute().inc(&key, &rate, 1).await?;
-
-    // Suppressed: probabilistic admission from local state.
-    let _decision = rl.hybrid().suppressed().inc(&key, &rate, 1).await?;
-
-    // Query suppression factor for observability.
-    let _sf = rl.hybrid().suppressed().get_suppression_factor(&key).await?;
+    assert!(matches!(
+        rl.redis().absolute().inc(&key, &rate, 1).await?,
+        RateLimitDecision::Allowed
+    ));
 
     Ok(())
 }
 ```
 
-## Core Concepts
+### Redis Suppressed State
 
-### Keyed Limiting
+```rust,no_run
+use trypema::RateLimiter;
+use trypema::redis::RedisKey;
 
-Every rate limiting operation targets a specific **key** — a string that identifies the
-resource being limited (e.g., a user ID, API endpoint, or IP address). Each key maintains
-completely independent rate limiting state.
+async fn example() -> Result<(), trypema::TrypemaError> {
+    let url = std::env::var("REDIS_URL")
+        .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+    let connection_manager = redis::Client::open(url)?
+        .get_connection_manager()
+        .await?;
 
-- **Local provider:** Keys are arbitrary `&str` values. Any string is valid.
-- **Redis / Hybrid providers:** Keys use the `RedisKey` newtype, which enforces validation
-  rules (non-empty, ≤ 255 bytes, no `:` character).
+    let rl = RateLimiter::builder(connection_manager).build()?;
+    let key = RedisKey::try_from("user_123".to_string())?;
 
-### Rate Limits
+    assert_eq!(rl.redis().suppressed().get_suppression_factor(&key).await?, 0.0);
 
-Rate limits are expressed as **requests per second** using the `RateLimit` type, which wraps
-a positive `f64`. Non-integer rates like `0.5` (one request every 2 seconds) or `5.5` are
-fully supported.
-
-The actual **window capacity** — the maximum number of requests allowed within the sliding
-window — is computed as:
-
-```text
-window_capacity = window_size_seconds × rate_limit
+    Ok(())
+}
 ```
 
-**Example:** With a 60-second window and a rate limit of `5.0`:
+### Hybrid Absolute
 
-- Window capacity = 60 × 5.0 = **300 requests**
+```rust,no_run
+use trypema::{RateLimit, RateLimitDecision, RateLimiter};
+use trypema::redis::RedisKey;
 
-### Sliding Windows
+async fn example() -> Result<(), trypema::TrypemaError> {
+    let url = std::env::var("REDIS_URL")
+        .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+    let connection_manager = redis::Client::open(url)?
+        .get_connection_manager()
+        .await?;
 
-Trypema uses a **sliding time window** for admission decisions. At any point in time,
-the limiter considers all activity within the last `window_size_seconds`. As time advances,
-old buckets expire and new capacity becomes available continuously.
+    let rl = RateLimiter::builder(connection_manager).build()?;
+    let key = RedisKey::try_from("user_123".to_string())?;
+    let rate = RateLimit::try_from(10.0).unwrap();
 
-This avoids the boundary-reset problem of fixed windows, where a burst at the end of one
-window followed by a burst at the start of the next could allow 2× the intended rate.
+    assert!(matches!(
+        rl.hybrid().absolute().inc(&key, &rate, 1).await?,
+        RateLimitDecision::Allowed
+    ));
 
-### Bucket Coalescing
-
-To reduce memory and computational overhead, increments that occur within
-`rate_group_size_ms` of each other are merged into the same time bucket rather than
-tracked individually.
-
-For example, with `rate_group_size_ms = 10`:
-
-- 50 requests arriving within 10ms produce **1 bucket** with count = 50
-- 50 requests spread over 100ms produce roughly **10 buckets** with count ≈ 5 each
-
-Coarser coalescing (larger values) means fewer buckets, less memory, and faster iteration
-but also less precise `retry_after_ms` estimates in rejection metadata.
-
-### Sticky Rate Limits
-
-The first `inc()` call for a given key stores the rate limit for that key's lifetime in the
-limiter. Subsequent `inc()` calls for the same key use the stored limit and ignore the
-`rate_limit` argument.
-
-This prevents races where concurrent callers might specify different limits for the same key.
-If you need to change a key's rate limit, you must let the old entry expire (or be cleaned up)
-and start fresh.
-
-## Configuration
-
-### `LocalRateLimiterOptions`
-
-| Field                         | Type                       | Default      | Valid Range | Description                                                                   |
-| ----------------------------- | -------------------------- | ------------ | ----------- | ----------------------------------------------------------------------------- |
-| `window_size_seconds`         | `WindowSizeSeconds`        | _(required)_ | ≥ 1         | Length of the sliding window. Larger = smoother but slower recovery.          |
-| `rate_group_size_ms`          | `RateGroupSizeMs`          | 100 ms       | ≥ 1         | Bucket coalescing interval. Larger = less memory, coarser timing.             |
-| `hard_limit_factor`           | `HardLimitFactor`          | 1.0          | ≥ 1.0       | Multiplier for hard cutoff in suppressed strategy. Ignored by absolute.       |
-| `suppression_factor_cache_ms` | `SuppressionFactorCacheMs` | 100 ms       | ≥ 1         | How long to cache the computed suppression factor per key before recomputing. |
-
-### `RedisRateLimiterOptions`
-
-Includes the same four fields as `LocalRateLimiterOptions`, plus:
-
-| Field                | Type                | Default      | Description                                                                                                      |
-| -------------------- | ------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `connection_manager` | `ConnectionManager` | _(required)_ | Redis connection (handles pooling and reconnection).                                                             |
-| `prefix`             | `Option<RedisKey>`  | `"trypema"`  | Namespace prefix for all Redis keys. Pattern: `{prefix}:{user_key}:{rate_type}:{suffix}`.                        |
-| `sync_interval_ms`   | `SyncIntervalMs`    | 10 ms        | How often the **hybrid** provider flushes local increments to Redis. The pure Redis provider ignores this value. |
+    Ok(())
+}
+```
 
 ## Rate Limit Decisions
 
-All strategies return a `RateLimitDecision` enum with three variants:
+Every strategy returns `RateLimitDecision`:
 
-### `Allowed`
+- `Allowed` means the request should proceed.
+- `Rejected` means the absolute strategy denied the request and includes best-effort backoff
+  hints.
+- `Suppressed` means the suppressed strategy is active; check `is_allowed` for the admission
+  result.
 
-The request is within the rate limit. The increment has been recorded in the limiter's state.
+## Notes
 
-### `Rejected`
+- Rate limits are sticky per key: the first `inc()` stores the key's rate limit.
+- Bucket coalescing trades timing precision for lower overhead.
+- Redis and hybrid modes provide best-effort distributed limiting, not strict linearizability.
 
-The request exceeds the rate limit and should not proceed. The increment was **not** recorded.
+## Testing Redis-Backed Docs
 
-**Fields:**
-
-- `window_size_seconds` — The configured sliding window size (in seconds).
-- `retry_after_ms` — **Best-effort** estimate of milliseconds until capacity becomes available.
-  Computed from the oldest active bucket's remaining TTL. Use this to set an HTTP `Retry-After`
-  header or as a backoff hint.
-- `remaining_after_waiting` — **Best-effort** estimate of how many requests will still be
-  counted in the window after `retry_after_ms` elapses.
-
-**Important:** These hints are approximate. Bucket coalescing and concurrent access both
-reduce accuracy. Use them for guidance, not as strict guarantees.
-
-### `Suppressed`
-
-Only returned by the suppressed strategy. Indicates that probabilistic suppression is active.
-
-**Fields:**
-
-- `suppression_factor` — The current suppression rate (0.0 = no suppression, 1.0 = full suppression).
-- `is_allowed` — Whether this specific call was admitted. **Always use this field as the
-  admission decision**, not the variant name alone.
-
-**Tracking observed vs. declined:**
-
-The suppressed strategy tracks two counters per key:
-
-- **observed** (`total`): all calls seen (always incremented, regardless of admission)
-- **declined**: calls denied by suppression (`is_allowed: false`)
-
-From these you can derive accepted usage: `accepted = observed - declined`.
-
-## Rate Limiting Strategies
-
-### Absolute Strategy
-
-**Access:** `rl.local().absolute()`, `rl.redis().absolute()`, or `rl.hybrid().absolute()`
-
-A deterministic sliding-window limiter that strictly enforces rate limits.
-
-**How it works:**
-
-1. Compute window capacity: `window_size_seconds × rate_limit`
-2. Sum all bucket counts within the current sliding window
-3. If `total < capacity` → allow and record the increment
-4. If `total >= capacity` → reject (increment is **not** recorded)
-
-**Characteristics:**
-
-- Predictable, binary decisions (allowed or rejected)
-- Rate limits are **sticky** — the first `inc()` call for a key stores the limit
-- Rejected requests include best-effort backoff hints
-- Best-effort under concurrent load: multiple threads may observe "allowed" simultaneously
-
-**Use cases:**
-
-- Simple per-key rate caps (e.g., API rate limiting)
-- Scenarios where predictable enforcement matters more than graceful degradation
-- Both single-process (local) and multi-process (Redis/hybrid) deployments
-
-### Suppressed Strategy
-
-**Access:** `rl.local().suppressed()`, `rl.redis().suppressed()`, or `rl.hybrid().suppressed()`
-
-A probabilistic strategy that gracefully degrades under load by suppressing an increasing
-fraction of requests as the key approaches and exceeds its limit.
-
-**Three operating regimes:**
-
-1. **Below capacity** — Suppression factor is `0.0`. All requests return `Allowed`.
-
-2. **At or above capacity (below hard limit)** — A suppression factor is computed and
-   each request is probabilistically allowed with probability `1.0 - suppression_factor`.
-   Returns `Suppressed { is_allowed: true/false, suppression_factor }`.
-
-3. **Over hard limit** (`observed_usage >= window_capacity × hard_limit_factor`) —
-   Suppression factor is `1.0`. All requests denied.
-
-**Suppression factor calculation:**
-
-```text
-suppression_factor = 1.0 - (rate_limit / perceived_rate)
-
-where: perceived_rate = max(average_rate_in_window, rate_in_last_1000ms)
-```
-
-The `rate_in_last_1000ms` term is computed at millisecond granularity, allowing suppression
-to respond quickly to short traffic spikes.
-
-**Inspiration:** Based on
-[Ably's distributed rate limiting approach](https://ably.com/blog/distributed-rate-limiting-scale-your-platform).
-
-## Providers In-Depth
-
-### Local Provider
-
-**Access:** `rl.local()`
-
-Stores all state in-process using `DashMap` with atomic counters. Sub-microsecond latency,
-no external dependencies.
-
-**Best-effort concurrency:** The admission check and increment are not a single atomic
-operation. Under high concurrency, multiple threads can observe "allowed" simultaneously
-and all proceed, causing temporary overshoot. This is by design for performance.
-
-### Redis Provider
-
-**Access:** `rl.redis()`
-
-Executes all operations as atomic Lua scripts against Redis 7.2+. Each call results in one
-Redis round-trip.
-
-**Server-side timestamps:** Lua scripts use `redis.call("TIME")` for all timestamp
-calculations, avoiding client clock skew issues.
-
-**Data model:** For a key `K` with prefix `P` and rate type `T`:
-
-| Redis Key           | Type       | Purpose                                                 |
-| ------------------- | ---------- | ------------------------------------------------------- |
-| `P:K:T:h`           | Hash       | Sliding window buckets (`timestamp_ms → count`)         |
-| `P:K:T:a`           | Sorted Set | Active bucket timestamps (for efficient eviction)       |
-| `P:K:T:w`           | String     | Window limit (set on first call, refreshed with EXPIRE) |
-| `P:K:T:t`           | String     | Total count across all buckets                          |
-| `P:K:T:d`           | String     | Total declined count (suppressed strategy only)         |
-| `P:K:T:hd`          | Hash       | Declined counts per bucket (suppressed only)            |
-| `P:K:T:sf`          | String     | Cached suppression factor with PX TTL (suppressed only) |
-| `P:active_entities` | Sorted Set | All active keys (used by cleanup)                       |
-
-### Hybrid Provider
-
-**Access:** `rl.hybrid()`
-
-Maintains local in-memory state per key with a background actor that periodically batches
-increments and flushes them to Redis. Between flushes, admission is served from local state
-without Redis I/O.
-
-**When to use:** When per-request Redis latency is unacceptable. Trade-off: admission decisions
-may lag behind Redis state by up to `sync_interval_ms`.
-
-## Important Semantics & Limitations
-
-### Eviction Granularity
-
-**Local provider:** Uses `Instant::elapsed().as_millis()` (millisecond granularity, lazy eviction).
-
-**Redis provider:** Uses Redis server time in milliseconds inside Lua scripts; auxiliary keys
-use standard TTL commands.
-
-### Memory Growth
-
-Keys are **not automatically removed** when inactive. Use `run_cleanup_loop()` to periodically
-remove stale keys:
-
-```rust,no_run
-use std::sync::Arc;
-
-use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-use trypema::local::LocalRateLimiterOptions;
-
-let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-let hard_limit_factor = HardLimitFactor::default();
-let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-
-let options = RateLimiterOptions {
-    local: LocalRateLimiterOptions {
-        window_size_seconds,
-        rate_group_size_ms,
-        hard_limit_factor,
-        suppression_factor_cache_ms,
-    },
-};
-
-let rl = Arc::new(RateLimiter::new(options));
-
-// Default: stale_after = 10 minutes, cleanup_interval = 30 seconds.
-rl.run_cleanup_loop();
-
-// Or with custom timing:
-// rl.run_cleanup_loop_with_config(5 * 60 * 1000, 60 * 1000);
-
-// Stop cleanup (best-effort, exits on next tick).
-rl.stop_cleanup_loop();
-```
-
-**Memory safety:** The cleanup loop holds only a `Weak<RateLimiter>` reference. Dropping all
-`Arc` references automatically stops cleanup.
-
-## Tuning Guide
-
-### `window_size_seconds`
-
-**What it controls:** How far back in time the limiter looks when making admission decisions.
-
-- **Larger windows** (60–300s): smooth out bursts, more forgiving. But slower recovery and
-  higher memory per key.
-- **Smaller windows** (5–30s): faster recovery, lower memory. But less burst tolerance.
-
-**Recommendation:** Start with **60 seconds**.
-
-### `rate_group_size_ms`
-
-**What it controls:** Coalescing interval for grouping increments into time buckets.
-
-- **Larger** (50–100ms): fewer buckets, less memory, better performance. Coarser `retry_after_ms`.
-- **Smaller** (1–20ms): more accurate metadata, finer tracking. Higher memory and overhead.
-
-**Recommendation:** Start with **10ms**.
-
-### `hard_limit_factor`
-
-**What it controls:** Hard cutoff multiplier for the suppressed strategy.
-`hard_limit = rate_limit × hard_limit_factor`.
-
-- `1.0` (default): no headroom, suppressed strategy behaves more like absolute.
-- `1.5–2.0` (**recommended**): smooth degradation with 50–100% burst headroom.
-- `> 2.0`: very permissive gap between suppression start and hard limit.
-
-**Only relevant for:** Suppressed strategy. Absolute ignores this.
-
-### `suppression_factor_cache_ms`
-
-**What it controls:** How long the computed suppression factor is cached per key.
-
-- Shorter (10–50ms): faster reaction to traffic changes, more CPU.
-- Longer (100–1000ms): less overhead, slower reaction.
-
-**Recommendation:** Start with **100ms** (the default).
-
-### `sync_interval_ms` (Hybrid provider only)
-
-**What it controls:** How often the hybrid provider flushes local increments to Redis.
-
-- Shorter (5–10ms): less lag, more Redis writes.
-- Longer (50–100ms): fewer writes, more stale decisions.
-
-**Recommendation:** Start with **10ms** (the default). Keep `sync_interval_ms` ≤ `rate_group_size_ms`.
-
-## Redis Provider Details
-
-This section applies to both the **Redis** and **Hybrid** providers.
-
-### Requirements
-
-- **Redis version:** >= 7.2.0
-- **Async runtime:** Tokio or Smol
-
-### Key Constraints
-
-Redis keys use the `RedisKey` newtype with validation:
-
-- **Must not be empty**
-- **Must be ≤ 255 bytes**
-- **Must not contain** `:` (used internally as a separator)
-
-```rust,no_run
-use trypema::redis::RedisKey;
-
-// Valid keys
-let _ = RedisKey::try_from("user_123".to_string()).unwrap();
-let _ = RedisKey::try_from("api_v2_endpoint".to_string()).unwrap();
-
-// Invalid: contains ':'
-let _ = RedisKey::try_from("user:123".to_string()); // Err
-
-// Invalid: empty
-let _ = RedisKey::try_from("".to_string()); // Err
-```
-
-### Feature Flags
-
-Control Redis support at compile time:
-
-```toml
-# Default: local-only (no Redis dependency)
-trypema = { version = "1.0" }
-
-# Enable Redis + hybrid providers with Tokio runtime
-trypema = { version = "1.0", features = ["redis-tokio"] }
-
-# Enable Redis + hybrid providers with Smol runtime
-trypema = { version = "1.0", default-features = false, features = ["redis-smol"] }
-```
-
-The `redis-tokio` and `redis-smol` features are **mutually exclusive**. Enabling both
-produces a compile error.
-
-## Project Structure
-
-```text
-src/
-├── lib.rs                               # Crate root: re-exports, feature gates, module declarations
-├── rate_limiter.rs                      # RateLimiter facade + RateLimiterOptions
-├── common.rs                            # Shared types (RateLimitDecision, RateLimit, WindowSizeSeconds, etc.)
-├── error.rs                             # TrypemaError enum
-├── runtime.rs                           # Async runtime abstraction (tokio / smol)
-├── local/
-│   ├── mod.rs                           # Local provider module
-│   ├── local_rate_limiter_provider.rs   # LocalRateLimiterProvider + LocalRateLimiterOptions
-│   ├── absolute_local_rate_limiter.rs   # AbsoluteLocalRateLimiter
-│   └── suppressed_local_rate_limiter.rs # SuppressedLocalRateLimiter
-├── redis/
-│   ├── mod.rs                           # Redis provider module
-│   ├── common.rs                        # RedisKey, RedisKeyGenerator
-│   ├── redis_rate_limiter_provider.rs   # RedisRateLimiterProvider + RedisRateLimiterOptions
-│   ├── absolute_redis_rate_limiter.rs   # AbsoluteRedisRateLimiter (Lua scripts)
-│   └── suppressed_redis_rate_limiter.rs # SuppressedRedisRateLimiter (Lua scripts)
-└── hybrid/
-    ├── mod.rs                           # Hybrid provider module
-    ├── common.rs                        # SyncIntervalMs, committer utilities
-    ├── hybrid_rate_limiter_provider.rs  # HybridRateLimiterProvider
-    ├── absolute_hybrid_rate_limiter.rs  # AbsoluteHybridRateLimiter (state machine)
-    ├── absolute_hybrid_redis_proxy.rs   # Redis I/O proxy for absolute hybrid
-    ├── suppressed_hybrid_rate_limiter.rs # SuppressedHybridRateLimiter (state machine)
-    ├── suppressed_hybrid_redis_proxy.rs # Redis I/O proxy for suppressed hybrid
-    └── redis_commiter.rs               # RedisCommitter: background batch-flush actor
-```
-
-## Running Redis-Backed Tests
-
-The Redis and hybrid provider integration tests require a running Redis instance.
-Set `REDIS_URL` to enable them:
+The canonical runnable examples live in the crate docs and API docs. Redis and hybrid doctests
+need a live Redis instance and `REDIS_URL`, for example:
 
 ```bash
-REDIS_URL=redis://127.0.0.1:6379/ cargo test --features redis-tokio
+REDIS_URL=redis://127.0.0.1:6379/ cargo test -p trypema --doc --features redis-tokio
 ```
 
-## Roadmap
-
-**Planned:**
-
-- [ ] Metrics and observability hooks
-
-**Non-goals:**
-
-- Strict linearizability (by design)
-- Built-in retry logic (application-specific)
-
-## Contributing
-
-Feedback, issues, and PRs are welcome. Please include tests for new features.
-
-## License
-
-MIT License. See the [LICENSE](LICENSE) file for details.
+Use `redis-smol` instead when validating the Smol-backed feature set.

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -25,11 +25,12 @@ pub const BENCH_PREFIX: &str = "bench";
 pub mod redis {
     use std::{env, sync::Arc};
 
-    use trypema::{
-        HardLimitFactor, RateGroupSizeMs, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs,
-        WindowSizeSeconds, hybrid::SyncIntervalMs, local::LocalRateLimiterOptions,
-    };
     use trypema::redis::{RedisKey, RedisRateLimiterOptions};
+    use trypema::{
+        HardLimitFactor, RateGroupSizeMs, RateLimiter, RateLimiterOptions,
+        SuppressionFactorCacheMs, WindowSizeSeconds, hybrid::SyncIntervalMs,
+        local::LocalRateLimiterOptions,
+    };
 
     /// Read `REDIS_URL` from the environment, defaulting to the local dev address.
     pub fn redis_url() -> String {

--- a/benches/redis_suppressed.rs
+++ b/benches/redis_suppressed.rs
@@ -13,8 +13,8 @@ mod enabled {
     use criterion::Criterion;
     use std::hint::black_box;
 
-    use trypema::redis::RedisKey;
     use trypema::RateLimit;
+    use trypema::redis::RedisKey;
 
     use super::common::redis::{LimiterConfig, build_limiter};
     use super::runtime;
@@ -25,10 +25,13 @@ mod enabled {
 
         let rt = runtime::build();
 
-        let rl = runtime::block_on(&rt, build_limiter(LimiterConfig {
-            hard_limit_factor: 1.5,
-            ..LimiterConfig::default()
-        }));
+        let rl = runtime::block_on(
+            &rt,
+            build_limiter(LimiterConfig {
+                hard_limit_factor: 1.5,
+                ..LimiterConfig::default()
+            }),
+        );
 
         let key = RedisKey::try_from("user_1".to_string()).unwrap();
         let rate = RateLimit::try_from(5.0).unwrap();

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,59 @@
+# Documentation Conventions
+
+This file is the canonical documentation style guide for this repository.
+
+## Top-Level Docs Split
+
+- `docs/lib.md` is the canonical docs.rs source and is included by `src/lib.rs`.
+- `README.md` is the GitHub- and crates-facing companion document.
+- Keep the two documents structurally aligned, but let `docs/lib.md` carry the richer Rustdoc
+  linking and feature-aware behavior.
+
+## Link Policy
+
+- In `docs/lib.md`, prefer Rustdoc intra-doc links for public types, functions, and enums when the
+  target is available in that feature context.
+- In `README.md`, use inline code in prose instead of Rustdoc links.
+- Do not add links that break `cargo rustdoc --no-default-features -D warnings`.
+- For feature-gated APIs, either:
+  - gate the linked prose so it only appears when the item exists, or
+  - use plain inline code in shared prose.
+
+## Example Policy
+
+- Prefer runnable examples and doctests whenever practical.
+- `docs/lib.md` may use hidden `#` lines to keep examples clean on docs.rs.
+- `README.md` should not show docs.rs-only hidden scaffolding.
+- Keep examples focused and short. Prefer one concept per example.
+- When an example depends on Redis-backed features, make that explicit in prose or comments.
+
+## Builder and Setup Policy
+
+- Explain the local-only vs Redis-enabled builder split clearly:
+  - local-only: `RateLimiterBuilder::default()` or `RateLimiter::builder()`
+  - Redis-enabled: `RateLimiter::builder(connection_manager)`
+- Document the cleanup difference clearly:
+  - `RateLimiterBuilder::build()` starts cleanup automatically
+  - `RateLimiter::new(...)` does not
+- In builder examples, add short comments before chained setters:
+  - `Optional: ...`
+  - For Redis-only setters: `Optional: only available with 'redis-tokio' or 'redis-smol'`
+
+## Public API Doc Style
+
+- Start with a short purpose sentence.
+- Link related public APIs where it helps orientation.
+- Show flexibility in examples:
+  - multiple constructors (`new`, `try_from`, `new_or_panic`) where applicable
+  - defaults plus one override for options/builder types
+- Prefer behavior-level explanations over internal implementation detail unless the detail is
+  important for users.
+
+## Feature-Gated Items
+
+- Redis and hybrid APIs require Redis 7.2+.
+- Redis-only builder setters and Redis-related types should be explicitly marked as
+  feature-gated.
+- Keep docs warning-clean in both:
+  - `cargo rustdoc -p trypema --no-default-features -- -D warnings`
+  - `cargo rustdoc -p trypema --features redis-tokio -- -D warnings`

--- a/docs/lib.md
+++ b/docs/lib.md
@@ -18,935 +18,359 @@ a rate limiter is a narrow gate that controls the flow of requests into a system
 
 ## Overview
 
-Trypema is a Rust rate limiting library that supports both in-process and Redis-backed
-distributed enforcement. It provides two complementary strategies — strict enforcement and
-probabilistic suppression — across three provider backends.
+Trypema provides sliding-window rate limiting with two strategies across three providers:
 
-**Documentation:** <https://trypema.davidoyinbo.com>
+- **Local** for single-process, in-memory limiting
+- **Redis** for best-effort distributed limiting with one Redis round-trip per call
+- **Hybrid** for best-effort distributed limiting with a local fast path and periodic Redis sync
 
-**Benchmark comparisons:**
+Each provider offers:
 
-- Local provider: <https://trypema.davidoyinbo.com/benchmarks/benchmark-results/local-benchmark-comparison>
-- Redis provider: <https://trypema.davidoyinbo.com/benchmarks/benchmark-results/redis-benchmark-comparison>
+- **Absolute** for deterministic allow/reject decisions
+- **Suppressed** for probabilistic degradation near or above the target rate
 
-### Providers
+## Choosing a Provider
 
-Trypema organises rate limiting into three **providers**, each suited to different deployment
-scenarios:
+| Provider   | Best for                                             | Trade-off                                            |
+| ---------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| **Local**  | single-process services, jobs, CLIs                  | state is not shared across processes                 |
+| **Redis**  | strictest distributed coordination this crate offers | every check performs Redis I/O                       |
+| **Hybrid** | high-throughput distributed paths                    | decisions may lag behind Redis by `sync_interval_ms` |
 
-| Provider   | Backend                               | Latency                     | Consistency               | Use Case                         |
-| ---------- | ------------------------------------- | --------------------------- | ------------------------- | -------------------------------- |
-| **Local**  | In-process `DashMap` + atomics        | Sub-microsecond             | Single-process only       | CLI tools, single-server APIs    |
-| **Redis**  | Redis 7.2+ via Lua scripts            | Network round-trip per call | Distributed (best-effort) | Multi-process / multi-server     |
-| **Hybrid** | Local fast-path + periodic Redis sync | Sub-microsecond (fast-path) | Distributed with sync lag | High-throughput distributed APIs |
+## Installation
 
-### Strategies
+Local-only usage:
 
-Each provider exposes two **strategies** that determine how rate limit decisions are made:
+```toml
+[dependencies]
+trypema = "1"
+```
 
-- **Absolute** — A deterministic sliding-window limiter. Requests under the window capacity
-  are allowed; requests over it are immediately rejected. Simple and predictable.
+Redis-backed usage with Tokio:
 
-- **Suppressed** — A probabilistic strategy inspired by
-  [Ably's distributed rate limiting approach](https://ably.com/blog/distributed-rate-limiting-scale-your-platform).
-  Instead of a hard cutoff, it computes a _suppression factor_ and probabilistically denies a
-  fraction of requests proportional to how far over the limit the key is. This produces smooth
-  degradation rather than a cliff-edge rejection.
+```toml
+[dependencies]
+trypema = { version = "1", features = ["redis-tokio"] }
+```
 
-### Key Capabilities
+Redis-backed usage with Smol:
 
-- Non-integer rate limits (e.g., `0.5` or `5.5` requests per second)
-- Sliding time windows for smooth burst handling (no fixed-window boundary resets)
-- Configurable bucket coalescing to trade timing precision for lower overhead
-- Automatic background cleanup of stale keys (with `Weak` reference — no leak risk)
-- Best-effort rejection metadata (`retry_after_ms`, `remaining_after_waiting`) for backoff hints
-- Feature-flag driven compilation — zero Redis dependencies when you only need local limiting
+```toml
+[dependencies]
+trypema = { version = "1", features = ["redis-smol"] }
+```
 
-### Non-Goals
+Redis and hybrid providers require:
 
-This crate is **not** designed for:
-
-- **Strictly linearizable admission control.** Concurrent requests may temporarily overshoot
-  limits. This is by design: the library prioritises throughput over strict serialisation.
-- **Strong consistency in distributed scenarios.** Redis-backed limiting is best-effort;
-  multiple clients can exceed limits simultaneously during network partitions or high concurrency.
-- **Built-in retry logic.** Retry/backoff policies are application-specific and left to the caller.
+- Redis 7.2+
+- exactly one runtime feature: `redis-tokio` or `redis-smol`
 
 ## Quick Start
 
-### Local Provider (In-Process)
+### Common Types
 
-Use the local provider when you need single-process rate limiting with no external dependencies.
+[`RateLimit`](crate::RateLimit) is the per-second limit value used by all providers.
+`RedisKey` is the validated key type required by the Redis and hybrid providers when those
+features are enabled.
+[`RateLimitDecision`](crate::RateLimitDecision) is the result returned by methods such as
+[`AbsoluteLocalRateLimiter::inc`](crate::AbsoluteLocalRateLimiter::inc) and
+[`AbsoluteLocalRateLimiter::is_allowed`](crate::AbsoluteLocalRateLimiter::is_allowed), and
+[`RateLimiter`](crate::RateLimiter) is the top-level entry point used throughout the examples.
 
-```toml
-[dependencies]
-trypema = "1.0"
-```
-
-```rust,no_run
-use std::sync::Arc;
-
-use trypema::{
-    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions,
-    SuppressionFactorCacheMs, WindowSizeSeconds,
-};
-use trypema::local::LocalRateLimiterOptions;
+```rust
+use trypema::RateLimit;
 # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-# use trypema::redis::RedisRateLimiterOptions;
-# #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-# use trypema::hybrid::SyncIntervalMs;
+use trypema::redis::RedisKey;
 
-# fn options() -> RateLimiterOptions {
-#     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-#     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-#     let hard_limit_factor = HardLimitFactor::default();
-#     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-#     #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-#     let sync_interval_ms = SyncIntervalMs::default();
-#
-#     RateLimiterOptions {
-#         local: LocalRateLimiterOptions {
-#             window_size_seconds,
-#             rate_group_size_ms,
-#             hard_limit_factor,
-#             suppression_factor_cache_ms,
-#         },
-#         #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-#         redis: RedisRateLimiterOptions {
-#             connection_manager: todo!("create redis::aio::ConnectionManager"),
-#             prefix: None,
-#             window_size_seconds,
-#             rate_group_size_ms,
-#             hard_limit_factor,
-#             suppression_factor_cache_ms,
-#             sync_interval_ms,
-#         },
-#     }
+let _rate_a = RateLimit::new(5.0).unwrap();
+let _rate_b = RateLimit::try_from(5.0).unwrap();
+let _rate_c = RateLimit::new_or_panic(5.0);
+
+# #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+# {
+let _key_a = RedisKey::new("user_123".to_string()).unwrap();
+let _key_b = RedisKey::try_from("user_123".to_string()).unwrap();
+let _key_c = RedisKey::new_or_panic("user_123".to_string());
 # }
-
-let rl = Arc::new(RateLimiter::new(options()));
-
-// Start background cleanup to remove stale keys.
-// Idempotent: calling this multiple times is a no-op while running.
-rl.run_cleanup_loop();
-
-// Define a rate limit of 5 requests per second.
-// With a 60-second window, the window capacity is 60 × 5 = 300 requests.
-let key = "user_123";
-let rate_limit = RateLimit::try_from(5.0).unwrap();
-
-// --- Absolute strategy: deterministic sliding-window enforcement ---
-match rl.local().absolute().inc(key, &rate_limit, 1) {
-    RateLimitDecision::Allowed => {
-        // Under capacity — proceed with the request.
-    }
-    RateLimitDecision::Rejected { retry_after_ms, .. } => {
-        // Over capacity — reject and suggest the client retry later.
-        // `retry_after_ms` is a best-effort hint based on the oldest bucket's TTL.
-        let _ = retry_after_ms;
-    }
-    RateLimitDecision::Suppressed { .. } => {
-        unreachable!("absolute strategy never returns Suppressed");
-    }
-}
-
-// --- Suppressed strategy: probabilistic suppression near/over the limit ---
-//
-// You can query the suppression factor at any time for metrics/debugging.
-let sf = rl.local().suppressed().get_suppression_factor(key);
-let _ = sf;
-
-match rl.local().suppressed().inc(key, &rate_limit, 1) {
-    RateLimitDecision::Allowed => {
-        // Below capacity — no suppression active, proceed normally.
-    }
-    RateLimitDecision::Suppressed {
-        is_allowed: true,
-        suppression_factor,
-    } => {
-        // At/above capacity — suppression is active, but this particular request
-        // was probabilistically allowed. Proceed, but consider logging the factor.
-        let _ = suppression_factor;
-    }
-    RateLimitDecision::Suppressed {
-        is_allowed: false,
-        suppression_factor,
-    } => {
-        // At/above capacity — this request was probabilistically denied.
-        // Do NOT proceed. When over the hard limit, suppression_factor will be 1.0.
-        let _ = suppression_factor;
-    }
-    RateLimitDecision::Rejected { .. } => {
-        unreachable!("local suppressed strategy never returns Rejected");
-    }
-}
 ```
 
-### Redis Provider (Distributed)
+### Create a [`RateLimiter`](crate::RateLimiter)
 
-Use the Redis provider for distributed rate limiting across multiple processes or servers.
-Every `inc()` and `is_allowed()` call executes an atomic Lua script against Redis.
+[`RateLimiterBuilder`](crate::RateLimiterBuilder) is the fluent setup type behind
+[`RateLimiter::builder`](crate::RateLimiter::builder). Without Redis features you can start from
+`RateLimiterBuilder::default()` or [`RateLimiter::builder`](crate::RateLimiter::builder). With
+`redis-tokio` or `redis-smol`, use [`RateLimiter::builder`](crate::RateLimiter::builder) with a
+`connection_manager`, because the builder needs Redis connectivity up front.
 
-**Requirements:**
+Use `RateLimiterBuilder::default()` when you want to start from local-only defaults and override
+just a few optional settings.
 
-- Redis >= 7.2
-- Tokio or Smol async runtime
+```rust
+# #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+# {
+use trypema::{RateLimit, RateLimitDecision, RateLimiterBuilder};
 
-```toml
-[dependencies]
-trypema = { version = "1.0", features = ["redis-tokio"] }
-redis = { version = "1", default-features = false, features = ["aio", "tokio-comp", "connection-manager"] }
-tokio = { version = "1", features = ["full"] }
+let rl = RateLimiterBuilder::default()
+    // Optional: override the sliding window size.
+    .window_size_seconds(60)
+    // Optional: override bucket coalescing.
+    .rate_group_size_ms(10)
+    // Optional: tune suppressed-mode headroom.
+    .hard_limit_factor(1.5)
+    // Optional: tune cleanup cadence.
+    .cleanup_interval_ms(15_000)
+    .build()
+    .unwrap();
+
+let rate = RateLimit::try_from(5.0).unwrap();
+
+assert!(matches!(
+    rl.local().absolute().inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
+# }
 ```
 
-```rust,no_run
-# async fn example() -> Result<(), trypema::TrypemaError> {
+Use the local-only [`RateLimiter::builder`](crate::RateLimiter::builder) helper when you want the
+simplest setup with defaults and automatic cleanup-loop startup.
+
+```rust
+# #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+# {
+use trypema::{RateLimit, RateLimitDecision, RateLimiter};
+
+let rl = RateLimiter::builder().build().unwrap();
+let rate = RateLimit::try_from(5.0).unwrap();
+
+assert!(matches!(
+    rl.local().absolute().inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
+# }
+```
+
+With `redis-tokio` or `redis-smol`, create the builder with a Redis `connection_manager`.
+
+```rust
 # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+# {
+# trypema::__doctest_helpers::with_redis_rate_limiter(|_rl| async move {
+use trypema::{RateLimit, RateLimitDecision, RateLimiter};
+use trypema::redis::RedisKey;
+
+let url = std::env::var("REDIS_URL")
+    .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+let connection_manager = redis::Client::open(url)
+    .unwrap()
+    .get_connection_manager()
+    .await
+    .unwrap();
+
+let rl = RateLimiter::builder(connection_manager)
+    // Optional: override the sliding window size.
+    .window_size_seconds(60)
+    // Optional: override bucket coalescing.
+    .rate_group_size_ms(10)
+    // Optional: tune suppressed-mode headroom.
+    .hard_limit_factor(1.5)
+    // Optional: only available with `redis-tokio` or `redis-smol`.
+    .redis_prefix(RedisKey::new_or_panic("docs".to_string()))
+    // Optional: only available with `redis-tokio` or `redis-smol`.
+    .sync_interval_ms(10)
+    .build()
+    .unwrap();
+
+let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+let rate = RateLimit::try_from(5.0).unwrap();
+
+assert!(matches!(
+    rl.redis().absolute().inc(&key, &rate, 1).await.unwrap(),
+    RateLimitDecision::Allowed
+));
+# let _ = _rl;
+# });
+# }
+```
+
+Use [`RateLimiterOptions`](crate::RateLimiterOptions) and
+[`LocalRateLimiterOptions`](crate::local::LocalRateLimiterOptions) when you want explicit control
+over configuration.
+
+```rust
+# #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
 # {
 use std::sync::Arc;
 
 use trypema::{
-    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions,
-    SuppressionFactorCacheMs, WindowSizeSeconds,
+    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter,
+    RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds,
 };
-use trypema::hybrid::SyncIntervalMs;
 use trypema::local::LocalRateLimiterOptions;
-use trypema::redis::{RedisKey, RedisRateLimiterOptions};
 
-// Create a Redis connection manager (handles pooling and reconnection).
-let client = redis::Client::open("redis://127.0.0.1:6379/").unwrap();
-let connection_manager = client.get_connection_manager().await.unwrap();
-
-let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-let hard_limit_factor = HardLimitFactor::default();
-let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-let sync_interval_ms = SyncIntervalMs::default();
-
-let rl = Arc::new(RateLimiter::new(RateLimiterOptions {
+let options = RateLimiterOptions {
     local: LocalRateLimiterOptions {
-        window_size_seconds,
-        rate_group_size_ms,
-        hard_limit_factor,
-        suppression_factor_cache_ms,
+        window_size_seconds: WindowSizeSeconds::new_or_panic(60),
+        rate_group_size_ms: RateGroupSizeMs::new_or_panic(10),
+        hard_limit_factor: HardLimitFactor::new_or_panic(1.5),
+        suppression_factor_cache_ms: SuppressionFactorCacheMs::new_or_panic(100),
     },
-    redis: RedisRateLimiterOptions {
-        connection_manager,
-        prefix: None, // Defaults to "trypema"
-        window_size_seconds,
-        rate_group_size_ms,
-        hard_limit_factor,
-        suppression_factor_cache_ms,
-        sync_interval_ms,
-    },
-}));
+};
 
+let rl = Arc::new(RateLimiter::new(options));
 rl.run_cleanup_loop();
 
-let rate_limit = RateLimit::try_from(5.0).unwrap();
-let key = RedisKey::try_from("user_123".to_string()).unwrap();
+let rate = RateLimit::try_from(5.0).unwrap();
 
-// --- Absolute strategy ---
-let decision = match rl.redis().absolute().inc(&key, &rate_limit, 1).await {
-    Ok(decision) => decision,
-    Err(e) => {
-        // Handle Redis errors (connectivity, script failures, etc.)
-        return Err(e);
-    }
-};
-
-match decision {
-    RateLimitDecision::Allowed => {
-        // Request allowed, proceed.
-    }
-    RateLimitDecision::Rejected { retry_after_ms, .. } => {
-        // Rejected — send HTTP 429 with Retry-After header.
-        let _ = retry_after_ms;
-    }
-    RateLimitDecision::Suppressed { .. } => {
-        unreachable!("absolute strategy never returns Suppressed");
-    }
-}
-
-// --- Suppressed strategy ---
-let sf = rl.redis().suppressed().get_suppression_factor(&key).await?;
-let _ = sf;
-
-let decision = match rl.redis().suppressed().inc(&key, &rate_limit, 1).await {
-    Ok(decision) => decision,
-    Err(e) => return Err(e),
-};
-
-match decision {
-    RateLimitDecision::Allowed => {
-        // Below capacity, proceed.
-    }
-    RateLimitDecision::Suppressed {
-        is_allowed: true,
-        suppression_factor,
-    } => {
-        // Suppression active but this request admitted.
-        let _ = suppression_factor;
-    }
-    RateLimitDecision::Suppressed {
-        is_allowed: false,
-        suppression_factor,
-    } => {
-        // Suppressed — do not proceed. When over the hard limit, suppression_factor is 1.0.
-        let _ = suppression_factor;
-    }
-    RateLimitDecision::Rejected { .. } => {
-        unreachable!("suppressed strategy never returns Rejected");
-    }
-}
-# }
-# Ok(())
+assert!(matches!(
+    rl.local().absolute().inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
 # }
 ```
 
-### Hybrid Provider (Local Fast-Path + Redis Sync)
+[`RateLimiterBuilder::build`](crate::RateLimiterBuilder::build) starts the cleanup loop
+automatically. [`RateLimiter::new`](crate::RateLimiter::new) does not, so call
+[`RateLimiter::run_cleanup_loop`](crate::RateLimiter::run_cleanup_loop) yourself when you want
+background cleanup of stale keys.
 
-The hybrid provider combines the low latency of in-process state with the distributed
-consistency of Redis. It maintains a local counter per key and periodically flushes
-accumulated increments to Redis in batches. Between flushes, admission decisions are
-served from local state without any Redis I/O.
+### Local Read-Only Check
 
-This is the recommended provider for high-throughput distributed APIs where per-request
-Redis round-trips are too expensive.
+Use [`AbsoluteLocalRateLimiter::is_allowed`](crate::AbsoluteLocalRateLimiter::is_allowed) when you
+want to inspect whether a request would be allowed without recording an increment.
 
-**Trade-off:** Admission decisions reflect Redis state with up to `sync_interval_ms` of lag.
+```rust
+# let rl = trypema::__doctest_helpers::rate_limiter();
+use trypema::{RateLimit, RateLimitDecision};
 
-```rust,no_run
-# async fn example() -> Result<(), trypema::TrypemaError> {
+let limiter = rl.local().absolute();
+let rate = RateLimit::try_from(5.0).unwrap();
+
+assert!(matches!(limiter.is_allowed("user_123"), RateLimitDecision::Allowed));
+assert!(matches!(
+    limiter.inc("user_123", &rate, 1),
+    RateLimitDecision::Allowed
+));
+```
+
+### Read Current Suppression State
+
+Use [`SuppressedLocalRateLimiter::get_suppression_factor`](crate::SuppressedLocalRateLimiter::get_suppression_factor)
+to inspect suppression state without recording a request.
+
+```rust
+# let rl = trypema::__doctest_helpers::rate_limiter();
+
+let sf = rl.local().suppressed().get_suppression_factor("user_123");
+assert_eq!(sf, 0.0);
+```
+
+### Redis Absolute
+
+Use the Redis provider when multiple processes or machines must share rate-limit state.
+
+```rust
 # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
 # {
-use std::sync::Arc;
+# trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+use trypema::{RateLimit, RateLimitDecision};
+use trypema::redis::RedisKey;
 
-use trypema::{
-    HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimiter, RateLimiterOptions,
-    SuppressionFactorCacheMs, WindowSizeSeconds,
-};
-use trypema::hybrid::SyncIntervalMs;
-use trypema::local::LocalRateLimiterOptions;
-use trypema::redis::{RedisKey, RedisRateLimiterOptions};
+let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+let rate = RateLimit::try_from(5.0).unwrap();
 
-let client = redis::Client::open("redis://127.0.0.1:6379/").unwrap();
-let connection_manager = client.get_connection_manager().await.unwrap();
-
-let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-let hard_limit_factor = HardLimitFactor::default();
-let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-let sync_interval_ms = SyncIntervalMs::default();
-
-let rl = Arc::new(RateLimiter::new(RateLimiterOptions {
-    local: LocalRateLimiterOptions {
-        window_size_seconds,
-        rate_group_size_ms,
-        hard_limit_factor,
-        suppression_factor_cache_ms,
-    },
-    redis: RedisRateLimiterOptions {
-        connection_manager,
-        prefix: None,
-        window_size_seconds,
-        rate_group_size_ms,
-        hard_limit_factor,
-        suppression_factor_cache_ms,
-        sync_interval_ms,
-    },
-}));
-
-let key = RedisKey::try_from("user_123".to_string())?;
-let rate = RateLimit::try_from(10.0)?;
-
-// Absolute: same API as the Redis provider, but served from local state.
-let _decision = rl.hybrid().absolute().inc(&key, &rate, 1).await?;
-
-// Suppressed: probabilistic admission from local state.
-let _decision = rl.hybrid().suppressed().inc(&key, &rate, 1).await?;
-
-// Query suppression factor for observability.
-let _sf = rl.hybrid().suppressed().get_suppression_factor(&key).await?;
-# }
-# Ok(())
+assert!(matches!(
+    rl.redis().absolute().inc(&key, &rate, 1).await.unwrap(),
+    RateLimitDecision::Allowed
+));
+# });
 # }
 ```
 
-## Running Redis-Backed Tests
+### Redis Suppressed State
 
-The Redis and hybrid provider integration tests require a running Redis instance.
-Set the `REDIS_URL` environment variable to enable them:
+Use `SuppressedRedisRateLimiter::get_suppression_factor` to inspect suppression state for a
+Redis-backed key.
 
-```bash
-REDIS_URL=redis://127.0.0.1:6379/ cargo test --features redis-tokio
+```rust
+# #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+# {
+# trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+use trypema::redis::RedisKey;
+
+let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+
+assert_eq!(rl.redis().suppressed().get_suppression_factor(&key).await.unwrap(), 0.0);
+# });
+# }
 ```
+
+### Hybrid
+
+The hybrid provider keeps a local fast path and periodically flushes to Redis, which is useful
+when per-request Redis I/O would be too expensive.
+
+```rust
+# #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+# {
+# trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+use trypema::{RateLimit, RateLimitDecision};
+use trypema::redis::RedisKey;
+
+let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+let rate = RateLimit::try_from(10.0).unwrap();
+
+assert!(matches!(
+    rl.hybrid().absolute().inc(&key, &rate, 1).await.unwrap(),
+    RateLimitDecision::Allowed
+));
+# });
+# }
+```
+
+## Understanding Decisions
+
+All strategies return [`RateLimitDecision`]:
+
+- [`Allowed`](crate::RateLimitDecision::Allowed): the request should proceed
+- [`Rejected`](crate::RateLimitDecision::Rejected): the absolute strategy denied the request and
+  includes best-effort backoff hints
+- [`Suppressed`](crate::RateLimitDecision::Suppressed): the suppressed strategy is active; check
+  `is_allowed` for the admission decision
+
+The rejection metadata and suppression factor are operational hints, not strict guarantees.
+Coalescing, concurrent callers, and distributed coordination can all affect precision.
 
 ## Core Concepts
 
-### Keyed Limiting
-
-Every rate limiting operation targets a specific **key** — a string that identifies the
-resource being limited (e.g., a user ID, API endpoint, or IP address). Each key maintains
-completely independent rate limiting state.
-
-- **Local provider:** Keys are arbitrary `&str` values. Any string is valid.
-- **Redis / Hybrid providers:** Keys use the `RedisKey` newtype, which
-  enforces validation rules (non-empty, ≤ 255 bytes, no `:` character).
-
-### Rate Limits
-
-Rate limits are expressed as **requests per second** using the [`RateLimit`] type, which wraps
-a positive `f64`. Non-integer rates like `0.5` (one request every 2 seconds) or `5.5` are
-fully supported.
-
-The actual **window capacity** — the maximum number of requests allowed within the sliding
-window — is computed as:
-
-```text
-window_capacity = window_size_seconds × rate_limit
-```
-
-**Example:** With a 60-second window and a rate limit of `5.0`:
-
-- Window capacity = 60 × 5.0 = **300 requests**
-
 ### Sliding Windows
 
-Trypema uses a **sliding time window** for admission decisions. At any point in time,
-the limiter considers all activity within the last `window_size_seconds`. As time advances,
-old buckets expire and new capacity becomes available continuously.
-
-This avoids the boundary-reset problem of fixed windows, where a burst at the end of one
-window followed by a burst at the start of the next could allow 2× the intended rate.
+Trypema uses a sliding window rather than a fixed window. Capacity becomes available continuously
+as old buckets expire, which avoids large boundary effects.
 
 ### Bucket Coalescing
 
-To reduce memory and computational overhead, increments that occur within
-`rate_group_size_ms` of each other are merged into the same time bucket rather than
-tracked individually.
+Increments close together in time are merged into one bucket using `rate_group_size_ms`. Larger
+values reduce overhead but make timing less precise.
 
-For example, with `rate_group_size_ms = 10`:
+### Sticky Per-Key Limits
 
-- 50 requests arriving within 10ms produce **1 bucket** with count = 50
-- 50 requests spread over 100ms produce roughly **10 buckets** with count ≈ 5 each
+The first [`AbsoluteLocalRateLimiter::inc`](crate::AbsoluteLocalRateLimiter::inc) call for a key
+stores that key's rate limit. Later calls for the same key reuse the stored limit so concurrent
+callers cannot race different limits into the same state.
 
-Coarser coalescing (larger values) means fewer buckets, less memory, and faster iteration
-but also less precise `retry_after_ms` estimates in rejection metadata.
+### Best-Effort Distributed Limiting
 
-### Sticky Rate Limits
+Redis and hybrid providers are designed for high throughput, not strict linearizability.
+Concurrent callers can temporarily overshoot the configured rate.
 
-The first `inc()` call for a given key stores the rate limit for that key's lifetime in the
-limiter. Subsequent `inc()` calls for the same key use the stored limit and ignore the
-`rate_limit` argument.
+## Running the Examples
 
-This prevents races where concurrent callers might specify different limits for the same key.
-If you need to change a key's rate limit, you must let the old entry expire (or be cleaned up)
-and start fresh.
+Local examples run with standard doctests.
 
-## Configuration
+Redis and hybrid examples require a live Redis server and `REDIS_URL`, for example:
 
-### `LocalRateLimiterOptions`
-
-| Field                         | Type                         | Default      | Valid Range | Description                                                                   |
-| ----------------------------- | ---------------------------- | ------------ | ----------- | ----------------------------------------------------------------------------- |
-| `window_size_seconds`         | [`WindowSizeSeconds`]        | _(required)_ | ≥ 1         | Length of the sliding window. Larger = smoother but slower recovery.          |
-| `rate_group_size_ms`          | [`RateGroupSizeMs`]          | 100 ms       | ≥ 1         | Bucket coalescing interval. Larger = less memory, coarser timing.             |
-| `hard_limit_factor`           | [`HardLimitFactor`]          | 1.0          | ≥ 1.0       | Multiplier for hard cutoff in suppressed strategy. Ignored by absolute.       |
-| `suppression_factor_cache_ms` | [`SuppressionFactorCacheMs`] | 100 ms       | ≥ 1         | How long to cache the computed suppression factor per key before recomputing. |
-
-### `RedisRateLimiterOptions`
-
-Includes the same four fields as `LocalRateLimiterOptions`, plus:
-
-| Field                | Type                                       | Default      | Description                                                                                                      |
-| -------------------- | ------------------------------------------ | ------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `connection_manager` | `redis::aio::ConnectionManager`            | _(required)_ | Redis connection (handles pooling and reconnection).                                                             |
-| `prefix`             | `Option<RedisKey>`                         | `"trypema"`  | Namespace prefix for all Redis keys. Pattern: `{prefix}:{user_key}:{rate_type}:{suffix}`.                        |
-| `sync_interval_ms`   | `SyncIntervalMs`                           | 10 ms        | How often the **hybrid** provider flushes local increments to Redis. The pure Redis provider ignores this value. |
-
-## Rate Limit Decisions
-
-All strategies return a [`RateLimitDecision`] enum with three variants:
-
-### `Allowed`
-
-The request is within the rate limit. The increment has been recorded in the limiter's state.
-
-```rust
-use trypema::RateLimitDecision;
-
-let decision = RateLimitDecision::Allowed;
+```bash
+REDIS_URL=redis://127.0.0.1:6379/ cargo test -p trypema --doc --features redis-tokio
 ```
 
-### `Rejected`
-
-The request exceeds the rate limit and should not proceed. The increment was **not** recorded.
-
-```rust
-use trypema::RateLimitDecision;
-
-let decision = RateLimitDecision::Rejected {
-    window_size_seconds: 60,
-    retry_after_ms: 2500,
-    remaining_after_waiting: 45,
-};
-```
-
-**Fields:**
-
-- `window_size_seconds` — The configured sliding window size (in seconds).
-- `retry_after_ms` — **Best-effort** estimate of milliseconds until capacity becomes available.
-  Computed from the oldest active bucket's remaining TTL. Use this to set an HTTP `Retry-After`
-  header or as a backoff hint.
-- `remaining_after_waiting` — **Best-effort** estimate of how many requests will still be
-  counted in the window after `retry_after_ms` elapses. May be `0` if all activity is heavily
-  coalesced into the oldest bucket.
-
-**Important:** These hints are approximate. Bucket coalescing and concurrent access both
-reduce accuracy. Use them for guidance, not as strict guarantees.
-
-### `Suppressed`
-
-Only returned by the suppressed strategy. Indicates that probabilistic suppression is active
-because the key's observed rate is at or above its target capacity.
-
-```rust
-use trypema::RateLimitDecision;
-
-let decision = RateLimitDecision::Suppressed {
-    suppression_factor: 0.3,
-    is_allowed: true,
-};
-```
-
-**Fields:**
-
-- `suppression_factor` — The current suppression rate, ranging from `0.0` (no suppression)
-  to `1.0` (full suppression / all requests denied).
-- `is_allowed` — Whether this specific call was admitted. **Always use this field as the
-  admission decision**, not the variant name alone.
-
-**Tracking observed vs. declined:**
-
-The suppressed strategy tracks two counters per key:
-
-- **observed** (`total`): all calls seen (always incremented, regardless of admission)
-- **declined**: calls that were denied by suppression (`is_allowed: false`)
-
-From these you can derive accepted usage: `accepted = observed - declined`.
-
-## Rate Limiting Strategies
-
-### Absolute Strategy
-
-**Access:** `rl.local().absolute()`, `rl.redis().absolute()`, or `rl.hybrid().absolute()`
-
-A deterministic sliding-window limiter that strictly enforces rate limits.
-
-**How it works:**
-
-1. Compute window capacity: `window_size_seconds × rate_limit`
-2. Sum all bucket counts within the current sliding window
-3. If `total < capacity` → allow and record the increment
-4. If `total >= capacity` → reject (increment is **not** recorded)
-
-**Characteristics:**
-
-- Predictable, binary decisions (allowed or rejected)
-- Rate limits are **sticky** — the first `inc()` call for a key stores the limit
-- Rejected requests include best-effort backoff hints
-- Best-effort under concurrent load: multiple threads may observe "allowed" simultaneously
-
-**Use cases:**
-
-- Simple per-key rate caps (e.g., API rate limiting)
-- Scenarios where predictable enforcement matters more than graceful degradation
-- Both single-process (local) and multi-process (Redis/hybrid) deployments
-
-### Suppressed Strategy
-
-**Access:** `rl.local().suppressed()`, `rl.redis().suppressed()`, or `rl.hybrid().suppressed()`
-
-A probabilistic strategy that gracefully degrades under load by suppressing an increasing
-fraction of requests as the key approaches and exceeds its limit.
-
-**How it works:**
-
-The suppressed strategy operates in three regimes:
-
-**1. Below capacity** — When `accepted_usage < window_capacity`:
-
-- Suppression factor is `0.0`
-- All requests return [`RateLimitDecision::Allowed`]
-- No probabilistic logic involved
-
-**2. At or above capacity (but below hard limit)** — When usage exceeds the soft limit
-but hasn't reached `rate_limit × hard_limit_factor`:
-
-- A suppression factor is computed and cached per key
-- Each request is probabilistically allowed with probability `1.0 - suppression_factor`
-- Returns [`RateLimitDecision::Suppressed { is_allowed, suppression_factor }`]
-
-**3. Over hard limit** — When `observed_usage >= window_capacity × hard_limit_factor`:
-
-- Suppression factor is forced to `1.0`
-- All requests are denied
-- Returns `Suppressed { is_allowed: false, suppression_factor: 1.0 }`
-
-**Suppression factor calculation:**
-
-```text
-suppression_factor = 1.0 - (rate_limit / perceived_rate)
-
-where: perceived_rate = max(average_rate_in_window, rate_in_last_1000ms)
-```
-
-The `rate_in_last_1000ms` term is computed at millisecond granularity (not whole seconds),
-allowing suppression to respond quickly to short traffic spikes.
-
-**Use cases:**
-
-- Graceful degradation under load spikes (smooth ramp-up of rejections)
-- Observability: the suppression factor tells you _how close_ a key is to its limit
-- Load shedding with visibility into suppression rates for monitoring dashboards
-
-**Inspiration:** Based on
-[Ably's distributed rate limiting approach](https://ably.com/blog/distributed-rate-limiting-scale-your-platform),
-which favors probabilistic suppression over hard cutoffs for better system behaviour under load.
-
-## Providers In-Depth
-
-### Local Provider
-
-**Access:** `rl.local()`
-
-The local provider stores all state in-process using
-[`DashMap`](https://docs.rs/dashmap) (a concurrent hash map) with atomic counters for
-per-bucket counts. It requires no external dependencies and has sub-microsecond latency.
-
-**Thread safety:** All operations are safe for concurrent use. `DashMap` provides
-shard-level locking, and bucket counters use `AtomicU64`.
-
-**Best-effort concurrency:** The admission check (`is_allowed`) and the increment are not
-a single atomic operation. Under high concurrency, multiple threads can observe "allowed"
-simultaneously and all proceed, causing temporary overshoot. This is by design — the
-alternative (per-key locking) would significantly reduce throughput.
-
-### Redis Provider
-
-**Access:** `rl.redis()`
-
-The Redis provider executes all operations as atomic Lua scripts against a Redis 7.2+ server.
-Each `inc()` call (and `is_allowed()` for the absolute strategy) results in one Redis round-trip.
-
-**Atomic Lua scripts:** Within a single Lua script execution, Redis guarantees atomicity.
-This avoids TOCTOU (time-of-check-to-time-of-use) races between reading and updating state.
-However, overall rate limiting across multiple clients remains best-effort.
-
-**Server-side timestamps:** The Lua scripts use `redis.call("TIME")` for all timestamp
-calculations, avoiding issues with client clock skew.
-
-**Data model:** For a key `K` with prefix `P` and rate type `T`, the following Redis keys
-are used:
-
-| Redis Key           | Type       | Purpose                                                    |
-| ------------------- | ---------- | ---------------------------------------------------------- |
-| `P:K:T:h`           | Hash       | Sliding window buckets (`timestamp_ms → count`)            |
-| `P:K:T:a`           | Sorted Set | Active bucket timestamps (for efficient eviction)          |
-| `P:K:T:w`           | String     | Window limit (set on first call, refreshed with `EXPIRE`)  |
-| `P:K:T:t`           | String     | Total count across all buckets                             |
-| `P:K:T:d`           | String     | Total declined count (suppressed strategy only)            |
-| `P:K:T:hd`          | Hash       | Declined counts per bucket (suppressed strategy only)      |
-| `P:K:T:sf`          | String     | Cached suppression factor (with `PX` TTL, suppressed only) |
-| `P:active_entities` | Sorted Set | All active keys (used by cleanup)                          |
-
-### Hybrid Provider
-
-**Access:** `rl.hybrid()`
-
-The hybrid provider is a Redis-backed limiter that avoids per-request Redis I/O by maintaining
-local in-memory state per key. A background actor (the `RedisCommitter`) periodically batches
-local increments and flushes them to Redis, then reads back the updated Redis state to refresh
-the local view.
-
-**State machine (absolute):**
-
-- `Undefined` → First call reads Redis to initialise local state
-- `Accepting` → Serving from local counter (no Redis I/O per request)
-- `Rejecting` → Rejection cache based on oldest bucket's TTL
-
-**State machine (suppressed):**
-
-- `Undefined` → First call reads Redis to initialise
-- `Accepting` → Below capacity; all requests allowed from local state
-- `Suppressing` → At/above capacity; probabilistic admission based on the suppression factor
-  from the last Redis read (partial or full suppression depending on the factor)
-
-**Thundering herd prevention:** Each key has its own `tokio::sync::Mutex`. When local state
-is exhausted and a Redis read is needed, only one task performs the read; others wait and then
-re-check the refreshed state.
-
-**When to use hybrid over pure Redis:** When your application handles high request volumes
-and per-request Redis latency is unacceptable. The trade-off is that admission decisions may
-lag behind the true Redis state by up to `sync_interval_ms`.
-
-## Important Semantics & Limitations
-
-### Eviction Granularity
-
-**Local provider:** Uses `Instant::elapsed().as_millis()` for bucket expiration. Buckets
-expire close to `window_size_seconds` but are subject to ~1ms truncation and lazy eviction
-timing (expired buckets are only removed when the key is next accessed).
-
-**Redis provider:** Bucket eviction uses Redis server time in milliseconds inside Lua scripts.
-Auxiliary keys use standard Redis TTL commands (`EXPIRE`, `SET ... PX`).
-
-### Memory Growth
-
-Keys are **not automatically removed** when they become inactive. Without cleanup, unbounded
-or attacker-controlled key cardinality can lead to memory growth (in-process for local,
-Redis memory for Redis/hybrid).
-
-**Mitigation:** Call `run_cleanup_loop()` to start a background task that periodically removes
-stale keys:
-
-```rust,no_run
-use std::sync::Arc;
-
-use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-use trypema::local::LocalRateLimiterOptions;
-# #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-# use trypema::hybrid::SyncIntervalMs;
-# #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-# use trypema::redis::RedisRateLimiterOptions;
-
-# fn options() -> RateLimiterOptions {
-#     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-#     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-#     let hard_limit_factor = HardLimitFactor::default();
-#     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-#     #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-#     let sync_interval_ms = SyncIntervalMs::default();
-#
-#     RateLimiterOptions {
-#         local: LocalRateLimiterOptions {
-#             window_size_seconds,
-#             rate_group_size_ms,
-#             hard_limit_factor,
-#             suppression_factor_cache_ms,
-#         },
-#         #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-#         redis: RedisRateLimiterOptions {
-#             connection_manager: todo!("create redis::aio::ConnectionManager"),
-#             prefix: None,
-#             window_size_seconds,
-#             rate_group_size_ms,
-#             hard_limit_factor,
-#             suppression_factor_cache_ms,
-#             sync_interval_ms,
-#         },
-#     }
-# }
-
-let rl = Arc::new(RateLimiter::new(options()));
-
-// Default: stale_after = 10 minutes, cleanup_interval = 30 seconds.
-// Idempotent: calling this multiple times is a no-op while running.
-rl.run_cleanup_loop();
-
-// Or with custom timing:
-// rl.run_cleanup_loop_with_config(5 * 60 * 1000, 60 * 1000);
-
-// Stop cleanup (best-effort, background task exits on next tick).
-// Idempotent: safe to call multiple times.
-rl.stop_cleanup_loop();
-```
-
-**Memory safety:** The cleanup loop holds only a `Weak<RateLimiter>` reference, not a strong
-`Arc`. Dropping all `Arc` references automatically stops cleanup — there is no risk of the
-background task keeping the limiter alive indefinitely.
-
-## Tuning Guide
-
-### `window_size_seconds`
-
-**What it controls:** How far back in time the limiter looks when making admission decisions.
-
-**Trade-offs:**
-
-- **Larger windows** (60–300s): smooth out burst traffic; more forgiving for intermittent
-  usage patterns. But recovery after hitting limits is slower (old activity stays in the
-  window longer), and each key uses more memory.
-
-- **Smaller windows** (5–30s): faster recovery after hitting limits; lower memory usage.
-  But less burst tolerance and more sensitivity to temporary spikes.
-
-**Recommendation:** Start with **60 seconds** for most use cases.
-
-### `rate_group_size_ms`
-
-**What it controls:** The coalescing interval for grouping nearby increments into the same
-time bucket.
-
-**Trade-offs:**
-
-- **Larger coalescing** (50–100ms): fewer buckets per key, lower memory, better performance.
-  But `retry_after_ms` estimates in rejection metadata become coarser.
-
-- **Smaller coalescing** (1–20ms): more accurate rejection metadata; finer-grained tracking.
-  But higher memory usage and more overhead per increment.
-
-**Recommendation:** Start with **10ms**. Increase to 50–100ms if memory or performance becomes
-an issue.
-
-### `hard_limit_factor`
-
-**What it controls:** The hard cutoff multiplier for the suppressed strategy. The hard limit
-is computed as `rate_limit × hard_limit_factor`.
-
-**Values:**
-
-- `1.0` (default): The hard limit equals the base limit. Suppression has no headroom — once
-  the target rate is reached, the suppression factor immediately ramps to 1.0. This makes the
-  suppressed strategy behave more like the absolute strategy.
-- `1.5–2.0` (**recommended**): Allows 50–100% burst above the target rate. Suppression
-  ramps up gradually across this range, providing smooth degradation.
-- `> 2.0`: Very permissive. There is a large gap between when suppression begins and when
-  the hard limit is reached.
-
-**Only relevant for:** The suppressed strategy. The absolute strategy ignores this parameter.
-
-### `suppression_factor_cache_ms`
-
-**What it controls:** How long (in milliseconds) the computed suppression factor is cached
-per key before being recomputed.
-
-**Trade-offs:**
-
-- **Shorter cache** (10–50ms): suppression reacts faster to changing traffic patterns, but
-  recomputation happens more frequently.
-- **Longer cache** (100–1000ms): less CPU overhead from recomputation, but suppression may
-  lag behind sudden traffic changes.
-
-**Recommendation:** Start with **100ms** (the default).
-
-### `sync_interval_ms` (Hybrid provider only)
-
-**What it controls:** How often the hybrid provider's background actor flushes local
-increments to Redis.
-
-**Trade-offs:**
-
-- **Shorter interval** (5–10ms): less lag between local and Redis state, at the cost of
-  more frequent Redis writes.
-- **Longer interval** (50–100ms): fewer Redis writes, but admission decisions may be based
-  on stale state for longer.
-
-**Recommendation:** Start with **10ms** (the default). It is generally recommended to keep
-`sync_interval_ms` ≤ `rate_group_size_ms`.
-
-## Redis Provider Details
-
-This section applies to both the **Redis** and **Hybrid** providers.
-
-### Requirements
-
-- **Redis version:** >= 7.2.0 (required for Lua script features used internally)
-- **Async runtime:** Tokio (`redis-tokio` feature) or Smol (`redis-smol` feature)
-
-### Key Constraints
-
-Redis keys use the `RedisKey` newtype with validation:
-
-- **Must not be empty**
-- **Must be ≤ 255 bytes**
-- **Must not contain `:` (colon)** — used internally as a key separator
-
-```rust,no_run
-#[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-{
-    use trypema::redis::RedisKey;
-
-    // Valid keys
-    let _ = RedisKey::try_from("user_123".to_string()).unwrap();
-    let _ = RedisKey::try_from("api_v2_endpoint".to_string()).unwrap();
-
-    // Invalid: contains ':'
-    assert!(RedisKey::try_from("user:123".to_string()).is_err());
-
-    // Invalid: empty
-    assert!(RedisKey::try_from("".to_string()).is_err());
-}
-```
-
-### Feature Flags
-
-Control Redis support at compile time:
-
-```toml
-# Default: local-only (no Redis dependency)
-trypema = { version = "1.0" }
-
-# Enable Redis + hybrid providers with Tokio runtime
-trypema = { version = "1.0", features = ["redis-tokio"] }
-
-# Enable Redis + hybrid providers with Smol runtime
-trypema = { version = "1.0", default-features = false, features = ["redis-smol"] }
-```
-
-The `redis-tokio` and `redis-smol` features are **mutually exclusive**. Enabling both
-will produce a compile error.
-
-## Project Structure
-
-```text
-src/
-├── lib.rs                               # Crate root: re-exports, feature gates, module declarations
-├── rate_limiter.rs                      # RateLimiter facade + RateLimiterOptions
-├── common.rs                            # Shared types (RateLimitDecision, RateLimit, WindowSizeSeconds, etc.)
-├── error.rs                             # TrypemaError enum
-├── runtime.rs                           # Async runtime abstraction (tokio / smol)
-├── local/
-│   ├── mod.rs                           # Local provider module
-│   ├── local_rate_limiter_provider.rs   # LocalRateLimiterProvider + LocalRateLimiterOptions
-│   ├── absolute_local_rate_limiter.rs   # AbsoluteLocalRateLimiter
-│   └── suppressed_local_rate_limiter.rs # SuppressedLocalRateLimiter
-├── redis/
-│   ├── mod.rs                           # Redis provider module
-│   ├── common.rs                        # RedisKey, RedisKeyGenerator
-│   ├── redis_rate_limiter_provider.rs   # RedisRateLimiterProvider + RedisRateLimiterOptions
-│   ├── absolute_redis_rate_limiter.rs   # AbsoluteRedisRateLimiter (Lua scripts)
-│   └── suppressed_redis_rate_limiter.rs # SuppressedRedisRateLimiter (Lua scripts)
-└── hybrid/
-    ├── mod.rs                           # Hybrid provider module
-    ├── common.rs                        # SyncIntervalMs, committer utilities
-    ├── hybrid_rate_limiter_provider.rs  # HybridRateLimiterProvider
-    ├── absolute_hybrid_rate_limiter.rs  # AbsoluteHybridRateLimiter (state machine)
-    ├── absolute_hybrid_redis_proxy.rs   # Redis I/O proxy for absolute hybrid
-    ├── suppressed_hybrid_rate_limiter.rs # SuppressedHybridRateLimiter (state machine)
-    ├── suppressed_hybrid_redis_proxy.rs # Redis I/O proxy for suppressed hybrid
-    └── redis_commiter.rs               # RedisCommitter: background batch-flush actor
-```
-
-Rustdoc uses this file (`docs/lib.md`) for crate-level documentation; the `README.md` in
-the repository root covers the same material in a format suited for GitHub and crates.io.
-
-## Roadmap
-
-**Planned:**
-
-- [ ] Metrics and observability hooks
-
-**Non-goals:**
-
-- Strict linearizability (by design)
-- Built-in retry logic (application-specific)
-
-## Contributing
-
-Feedback, issues, and PRs are welcome. Please include tests for new features.
-
-## License
-
-MIT License. See the [LICENSE](https://github.com/davidoyinbo/trypema/blob/main/LICENSE) file for details.
+Use `redis-smol` instead when testing the Smol-backed feature set.

--- a/src/__doctest_helpers.rs
+++ b/src/__doctest_helpers.rs
@@ -1,0 +1,132 @@
+//! Setup helpers shared across all doc-test examples.
+//!
+//! This module is not part of the public API and will not appear in generated documentation.
+//! It is `#[doc(hidden)]` and exists solely to reduce boilerplate in doc-test code blocks.
+
+use std::sync::Arc;
+
+use crate::RateLimiter;
+
+#[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+use std::future::Future;
+
+/// Returns a unique key string for test isolation.
+///
+/// Generates a random suffix so parallel doc-tests do not collide on shared Redis state.
+pub fn unique_key() -> String {
+    let n: u64 = rand::random();
+    format!("dt_{n}")
+}
+
+#[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+fn redis_url() -> String {
+    std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string())
+}
+
+/// Creates an [`Arc<RateLimiter>`] ready for use in doc-test examples.
+///
+/// - **Without Redis features:** constructs a local-only limiter (no network I/O).
+/// - **With Redis features:** connects to `$REDIS_URL` (default: `redis://127.0.0.1:6379`)
+///   and returns a full limiter with local, Redis, and hybrid providers available.
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+pub fn rate_limiter() -> Arc<RateLimiter> {
+    RateLimiter::builder().build().unwrap()
+}
+
+/// Creates an [`Arc<RateLimiter>`] ready for use in doc-test examples.
+///
+/// Connects to `$REDIS_URL` (default: `redis://127.0.0.1:6379`) using the Tokio runtime.
+#[cfg(feature = "redis-tokio")]
+pub fn rate_limiter() -> Arc<RateLimiter> {
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let conn = redis::Client::open(redis_url())
+            .unwrap()
+            .get_connection_manager()
+            .await
+            .unwrap();
+        RateLimiter::builder(conn).build().unwrap()
+    })
+}
+
+/// Build a Redis-enabled [`Arc<RateLimiter>`] and run `f` on the same runtime.
+///
+/// This keeps connection setup and all Redis-backed operations inside one runtime-owned
+/// execution scope, which avoids dropped-runtime issues in doctests.
+#[cfg(feature = "redis-tokio")]
+pub fn with_redis_rate_limiter<F, Fut, T>(f: F) -> T
+where
+    F: FnOnce(Arc<RateLimiter>) -> Fut,
+    Fut: Future<Output = T>,
+{
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(async move {
+            let conn = redis::Client::open(redis_url())
+                .unwrap()
+                .get_connection_manager()
+                .await
+                .unwrap();
+            let rl = RateLimiter::builder(conn).build().unwrap();
+            f(rl).await
+        })
+}
+
+/// Creates an [`Arc<RateLimiter>`] ready for use in doc-test examples.
+///
+/// Connects to `$REDIS_URL` (default: `redis://127.0.0.1:6379`) using the Smol runtime.
+#[cfg(feature = "redis-smol")]
+pub fn rate_limiter() -> Arc<RateLimiter> {
+    smol::block_on(async {
+        let conn = redis::Client::open(redis_url())
+            .unwrap()
+            .get_connection_manager()
+            .await
+            .unwrap();
+        RateLimiter::builder(conn).build().unwrap()
+    })
+}
+
+/// Build a Redis-enabled [`Arc<RateLimiter>`] and run `f` on the same runtime.
+///
+/// This keeps connection setup and all Redis-backed operations inside one runtime-owned
+/// execution scope, which avoids dropped-runtime issues in doctests.
+#[cfg(feature = "redis-smol")]
+pub fn with_redis_rate_limiter<F, Fut, T>(f: F) -> T
+where
+    F: FnOnce(Arc<RateLimiter>) -> Fut,
+    Fut: Future<Output = T>,
+{
+    smol::block_on(async move {
+        let conn = redis::Client::open(redis_url())
+            .unwrap()
+            .get_connection_manager()
+            .await
+            .unwrap();
+        let rl = RateLimiter::builder(conn).build().unwrap();
+        f(rl).await
+    })
+}
+
+/// Drive an async expression to completion in doc-test examples.
+///
+/// Used to wrap async Redis/hybrid method calls in doc examples without requiring
+/// `#[tokio::main]` (which needs the `tokio/macros` feature).
+#[cfg(feature = "redis-tokio")]
+pub fn block_on<F, T>(f: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::runtime::Runtime::new().unwrap().block_on(f)
+}
+
+/// Drive an async expression to completion in doc-test examples.
+///
+/// Used to wrap async Redis/hybrid method calls in doc examples without requiring
+/// a specific runtime macro.
+#[cfg(feature = "redis-smol")]
+pub fn block_on<F, T>(f: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    smol::block_on(f)
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -238,6 +238,16 @@ impl RateLimit {
     pub fn max() -> Self {
         Self(f64::MAX)
     }
+
+    /// Fallible constructor. Equivalent to `TryFrom` but more ergonomic as a direct call.
+    pub fn new(value: f64) -> Result<Self, TrypemaError> {
+        Self::try_from(value)
+    }
+
+    /// Panicking constructor. The `_or_panic` suffix signals that this call can panic.
+    pub fn new_or_panic(value: f64) -> Self {
+        Self::try_from(value).expect("RateLimit value must be greater than 0")
+    }
 }
 
 impl Deref for RateLimit {
@@ -294,6 +304,25 @@ impl DerefMut for RateLimit {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct WindowSizeSeconds(u64);
+
+impl Default for WindowSizeSeconds {
+    /// Returns a window size of 10 seconds.
+    fn default() -> Self {
+        Self(10)
+    }
+}
+
+impl WindowSizeSeconds {
+    /// Fallible constructor. Equivalent to `TryFrom` but more ergonomic as a direct call.
+    pub fn new(value: u64) -> Result<Self, TrypemaError> {
+        Self::try_from(value)
+    }
+
+    /// Panicking constructor. The `_or_panic` suffix signals that this call can panic.
+    pub fn new_or_panic(value: u64) -> Self {
+        Self::try_from(value).expect("WindowSizeSeconds must be at least 1")
+    }
+}
 
 impl Deref for WindowSizeSeconds {
     type Target = u64;
@@ -368,6 +397,18 @@ impl Default for RateGroupSizeMs {
     /// Returns a rate group size of 100 ms.
     fn default() -> Self {
         Self(100)
+    }
+}
+
+impl RateGroupSizeMs {
+    /// Fallible constructor. Equivalent to `TryFrom` but more ergonomic as a direct call.
+    pub fn new(value: u64) -> Result<Self, TrypemaError> {
+        Self::try_from(value)
+    }
+
+    /// Panicking constructor. The `_or_panic` suffix signals that this call can panic.
+    pub fn new_or_panic(value: u64) -> Self {
+        Self::try_from(value).expect("RateGroupSizeMs must be greater than 0")
     }
 }
 
@@ -454,6 +495,18 @@ impl Default for HardLimitFactor {
     }
 }
 
+impl HardLimitFactor {
+    /// Fallible constructor. Equivalent to `TryFrom` but more ergonomic as a direct call.
+    pub fn new(value: f64) -> Result<Self, TrypemaError> {
+        Self::try_from(value)
+    }
+
+    /// Panicking constructor. The `_or_panic` suffix signals that this call can panic.
+    pub fn new_or_panic(value: f64) -> Self {
+        Self::try_from(value).expect("HardLimitFactor must be >= 1.0")
+    }
+}
+
 impl Deref for HardLimitFactor {
     type Target = f64;
 
@@ -529,6 +582,18 @@ impl Default for SuppressionFactorCacheMs {
     /// Returns a suppression factor cache duration of 100 ms.
     fn default() -> Self {
         Self(100)
+    }
+}
+
+impl SuppressionFactorCacheMs {
+    /// Fallible constructor. Equivalent to `TryFrom` but more ergonomic as a direct call.
+    pub fn new(value: u64) -> Result<Self, TrypemaError> {
+        Self::try_from(value)
+    }
+
+    /// Panicking constructor. The `_or_panic` suffix signals that this call can panic.
+    pub fn new_or_panic(value: u64) -> Self {
+        Self::try_from(value).expect("SuppressionFactorCacheMs must be greater than 0")
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 //! Common types shared across all rate limiting providers.
 //!
-//! This module defines the core types used throughout the crate. All public types are
-//! re-exported at the crate root for convenience.
+//! These types define Trypema's shared configuration and result model. They are all re-exported
+//! at the crate root for convenience.
 //!
 //! # Types
 //!
@@ -31,8 +31,7 @@ pub(crate) struct InstantRate {
 
 /// Result of a rate limit admission check.
 ///
-///
-/// Returned by all rate limiting strategies to indicate whether a request should proceed.
+/// Returned by every strategy to indicate whether a request should proceed.
 ///
 /// # Variants
 ///
@@ -48,74 +47,21 @@ pub(crate) struct InstantRate {
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
+/// # let rl = trypema::__doctest_helpers::rate_limiter();
 /// use trypema::{RateLimitDecision, RateLimit};
-/// # use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-/// # use trypema::local::LocalRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::redis::RedisRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::hybrid::SyncIntervalMs;
-/// #
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #     let sync_interval_ms = SyncIntervalMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #         redis: RedisRateLimiterOptions {
-/// #             connection_manager: todo!(),
-/// #             prefix: None,
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #             sync_interval_ms,
-/// #         },
-/// #     }
-/// # }
-/// #
-/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #     }
-/// # }
-/// #
-/// # let rl = RateLimiter::new(options());
-/// # let rate = RateLimit::try_from(10.0).unwrap();
+///
+/// let rate = RateLimit::try_from(10.0).unwrap();
 ///
 /// match rl.local().absolute().inc("user_123", &rate, 1) {
 ///     RateLimitDecision::Allowed => {
-///         // Process request
 ///         println!("Request allowed");
 ///     }
 ///     RateLimitDecision::Rejected { retry_after_ms, remaining_after_waiting, .. } => {
-///         // Send 429 with Retry-After header
 ///         println!("Rate limited, retry in {}ms", retry_after_ms);
 ///         println!("Estimated remaining: {}", remaining_after_waiting);
 ///     }
 ///     RateLimitDecision::Suppressed { is_allowed, suppression_factor } => {
-///         // Only from suppressed strategy
 ///         if is_allowed {
 ///             println!("Allowed with suppression factor {}", suppression_factor);
 ///         } else {
@@ -188,9 +134,10 @@ pub enum RateLimitDecision {
 
 /// Per-second rate limit for a key.
 ///
-/// Wraps a positive `f64` to support non-integer rates (e.g., `5.5` requests/second).
+/// Wraps a positive `f64` so Trypema can express non-integer limits such as `0.5` or `5.5`
+/// requests per second.
 ///
-/// Window capacity is computed as: `window_size_seconds × rate_limit`
+/// Window capacity is computed as `window_size_seconds × rate_limit`.
 ///
 /// # Implementation Notes
 ///
@@ -203,13 +150,14 @@ pub enum RateLimitDecision {
 /// ```
 /// use trypema::RateLimit;
 ///
-/// // Integer rate
-/// let rate = RateLimit::try_from(10.0).unwrap();
+/// let rate = RateLimit::new(10.0).unwrap();
 /// assert_eq!(*rate, 10.0);
 ///
-/// // Non-integer rate
 /// let rate = RateLimit::try_from(5.5).unwrap();
 /// assert_eq!(*rate, 5.5);
+///
+/// let rate = RateLimit::new_or_panic(2.5);
+/// assert_eq!(*rate, 2.5);
 ///
 /// // Invalid: must be positive
 /// assert!(RateLimit::try_from(0.0).is_err());
@@ -295,9 +243,11 @@ impl DerefMut for RateLimit {
 /// ```
 /// use trypema::WindowSizeSeconds;
 ///
-/// // Valid
-/// let window = WindowSizeSeconds::try_from(60).unwrap();
+/// let window = WindowSizeSeconds::new(60).unwrap();
 /// assert_eq!(*window, 60);
+///
+/// let window = WindowSizeSeconds::new_or_panic(30);
+/// assert_eq!(*window, 30);
 ///
 /// // Invalid: too small
 /// assert!(WindowSizeSeconds::try_from(0).is_err());
@@ -381,11 +331,12 @@ impl TryFrom<u64> for WindowSizeSeconds {
 /// ```
 /// use trypema::RateGroupSizeMs;
 ///
-/// // Recommended starting point
-/// let coalescing = RateGroupSizeMs::try_from(10).unwrap();
+/// let coalescing = RateGroupSizeMs::new(10).unwrap();
+/// assert_eq!(*coalescing, 10);
 ///
-/// // Higher performance, coarser timing
 /// let aggressive = RateGroupSizeMs::try_from(100).unwrap();
+/// let precise = RateGroupSizeMs::new_or_panic(1);
+/// let _ = (aggressive, precise);
 ///
 /// // Invalid
 /// assert!(RateGroupSizeMs::try_from(0).is_err());
@@ -469,14 +420,13 @@ impl TryFrom<u64> for RateGroupSizeMs {
 /// ```
 /// use trypema::{HardLimitFactor, RateLimit};
 ///
-/// // Default: no headroom
 /// let factor = HardLimitFactor::default();
 /// assert_eq!(*factor, 1.0);
 ///
-/// // Recommended: 50% burst headroom
-/// let factor = HardLimitFactor::try_from(1.5).unwrap();
+/// let factor = HardLimitFactor::new(1.5).unwrap();
 /// let rate = RateLimit::try_from(10.0).unwrap();
-/// // Hard limit = 10.0 × 1.5 = 15.0 req/s
+/// let bursty = HardLimitFactor::new_or_panic(2.0);
+/// let _ = (rate, bursty);
 ///
 /// // Invalid: must be at least 1.0
 /// assert!(HardLimitFactor::try_from(0.0).is_err());
@@ -565,12 +515,12 @@ pub(crate) enum RateType {
 /// ```
 /// use trypema::SuppressionFactorCacheMs;
 ///
-/// // Default: 100ms
 /// let cache = SuppressionFactorCacheMs::default();
 /// assert_eq!(*cache, 100);
 ///
-/// // Custom: 50ms for faster reaction
-/// let cache = SuppressionFactorCacheMs::try_from(50).unwrap();
+/// let cache = SuppressionFactorCacheMs::new(50).unwrap();
+/// let fast = SuppressionFactorCacheMs::new_or_panic(10);
+/// let _ = (cache, fast);
 ///
 /// // Invalid: 0ms
 /// assert!(SuppressionFactorCacheMs::try_from(0).is_err());

--- a/src/hybrid/absolute_hybrid_rate_limiter.rs
+++ b/src/hybrid/absolute_hybrid_rate_limiter.rs
@@ -219,6 +219,22 @@ impl AbsoluteHybridRateLimiter {
     /// - `Ok(Allowed)` — under limit, increment recorded locally
     /// - `Ok(Rejected { .. })` — over limit (may be served from local rejection cache)
     /// - `Err(TrypemaError)` — Redis error during state refresh
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// assert!(matches!(
+    ///     rl.hybrid().absolute().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub async fn inc(
         &self,
         key: &RedisKey,
@@ -246,6 +262,21 @@ impl AbsoluteHybridRateLimiter {
     /// - `Ok(Allowed)` — under limit
     /// - `Ok(Rejected { .. })` — over limit, includes best-effort backoff hints
     /// - `Err(TrypemaError)` — Redis error during state refresh
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// assert!(matches!(
+    ///     rl.hybrid().absolute().is_allowed(&key).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub async fn is_allowed(&self, key: &RedisKey) -> Result<RateLimitDecision, TrypemaError> {
         self.send_epoch_change_if_needed();
 

--- a/src/hybrid/absolute_hybrid_redis_proxy.rs
+++ b/src/hybrid/absolute_hybrid_redis_proxy.rs
@@ -122,6 +122,7 @@ const READ_STATE_SCRIPT: &str = r#"
     local active_keys = KEYS[2]
     local window_limit_key = KEYS[3]
     local total_count_key = KEYS[4]
+    local active_entities_key = KEYS[5]
 
     local entity = ARGV[1]
     local window_size_ms = tonumber(ARGV[2])
@@ -155,6 +156,8 @@ const READ_STATE_SCRIPT: &str = r#"
         oldest_count = tonumber(redis.call("HGET", hash_key, oldest_hash_fields[1])) or 0
         oldest_ttl = window_size_ms - timestamp_ms + (tonumber(oldest_hash_fields[2]) or 0)
     end
+
+    redis.call("ZADD", active_entities_key, timestamp_ms, entity)
 
     return {entity, total_count, window_limit or -1, oldest_ttl or -1, oldest_count or -1}
 "#;
@@ -231,6 +234,7 @@ impl AbsoluteHybridRedisProxy {
             .key(self.key_generator.get_active_keys(key))
             .key(self.key_generator.get_window_limit_key(key))
             .key(self.key_generator.get_total_count_key(key))
+            .key(self.key_generator.get_active_entities_key())
             .arg(key.as_str())
             .arg(self.window_size_ms)
             .invoke_async(&mut connection_manager)
@@ -335,6 +339,7 @@ impl AbsoluteHybridRedisProxy {
                     .key(self.key_generator.get_active_keys(key))
                     .key(self.key_generator.get_window_limit_key(key))
                     .key(self.key_generator.get_total_count_key(key))
+                    .key(self.key_generator.get_active_entities_key())
                     .arg(key.as_str())
                     .arg(self.window_size_ms),
             );

--- a/src/hybrid/common.rs
+++ b/src/hybrid/common.rs
@@ -30,9 +30,8 @@ pub(crate) enum RedisRateLimiterSignal {
 
 /// Sync interval (milliseconds) for the hybrid provider's background flush.
 ///
-/// The hybrid provider batches local increments and periodically commits them to Redis
-/// via a background actor (the `RedisCommitter`). This value controls
-/// how often that flush occurs.
+/// The hybrid provider batches local increments and periodically commits them to Redis via a
+/// background actor. This value controls how often that flush occurs.
 ///
 /// # Trade-offs
 ///
@@ -55,12 +54,11 @@ pub(crate) enum RedisRateLimiterSignal {
 /// ```
 /// use trypema::hybrid::SyncIntervalMs;
 ///
-/// // Default: 10ms
-/// let interval = SyncIntervalMs::default();
+/// let interval = SyncIntervalMs::new(10).unwrap();
 /// assert_eq!(*interval, 10);
 ///
-/// // Custom: 50ms for reduced Redis writes
 /// let interval = SyncIntervalMs::try_from(50).unwrap();
+/// let interval = SyncIntervalMs::new_or_panic(75);
 ///
 /// // Invalid: 0ms
 /// assert!(SyncIntervalMs::try_from(0).is_err());

--- a/src/hybrid/common.rs
+++ b/src/hybrid/common.rs
@@ -75,6 +75,18 @@ impl Default for SyncIntervalMs {
     }
 }
 
+impl SyncIntervalMs {
+    /// Fallible constructor. Equivalent to `TryFrom` but more ergonomic as a direct call.
+    pub fn new(value: u64) -> Result<Self, TrypemaError> {
+        Self::try_from(value)
+    }
+
+    /// Panicking constructor. The `_or_panic` suffix signals that this call can panic.
+    pub fn new_or_panic(value: u64) -> Self {
+        Self::try_from(value).expect("SyncIntervalMs must be greater than 0")
+    }
+}
+
 impl Deref for SyncIntervalMs {
     type Target = u64;
 

--- a/src/hybrid/hybrid_rate_limiter_provider.rs
+++ b/src/hybrid/hybrid_rate_limiter_provider.rs
@@ -11,8 +11,11 @@ use crate::{
 
 /// Provider for hybrid rate limiting (local fast-path + Redis sync).
 ///
-/// This provider is backed by Redis, but maintains per-key in-memory state to enable a low-latency
-/// fast-path. Local increments are periodically flushed to Redis in batches.
+/// This provider is backed by Redis, but keeps per-key in-memory state so common-case admission
+/// checks can avoid per-request Redis I/O. Local increments are flushed to Redis in batches.
+///
+/// It uses [`RedisRateLimiterOptions`] for the shared Redis connection and timing configuration,
+/// and exposes [`AbsoluteHybridRateLimiter`] and [`SuppressedHybridRateLimiter`] as strategies.
 ///
 /// Compared to the pure Redis provider (`rl.redis()`):
 /// - ✅ Lower steady-state latency for admission checks (no per-request Redis I/O)
@@ -27,7 +30,7 @@ use crate::{
 ///
 /// # Requirements
 ///
-/// - Redis 6.2+
+/// - Redis 7.2+
 /// - One of: `redis-tokio` or `redis-smol` features
 #[derive(Clone, Debug)]
 pub struct HybridRateLimiterProvider {
@@ -46,6 +49,22 @@ impl HybridRateLimiterProvider {
     /// Access the absolute strategy for strict sliding-window enforcement.
     ///
     /// See [`AbsoluteHybridRateLimiter`] for full documentation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// assert!(matches!(
+    ///     rl.hybrid().absolute().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub fn absolute(&self) -> &AbsoluteHybridRateLimiter {
         &self.absolute
     }
@@ -53,6 +72,22 @@ impl HybridRateLimiterProvider {
     /// Access the suppressed strategy for probabilistic suppression.
     ///
     /// See [`SuppressedHybridRateLimiter`] for full documentation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// assert!(matches!(
+    ///     rl.hybrid().suppressed().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub fn suppressed(&self) -> &SuppressedHybridRateLimiter {
         &self.suppressed
     }

--- a/src/hybrid/suppressed_hybrid_rate_limiter.rs
+++ b/src/hybrid/suppressed_hybrid_rate_limiter.rs
@@ -207,6 +207,18 @@ impl SuppressedHybridRateLimiter {
     ///
     /// This method is read-only with respect to request counts. It is useful for metrics
     /// and observability dashboards.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// // No state yet → 0.0 (no suppression)
+    /// assert_eq!(rl.hybrid().suppressed().get_suppression_factor(&key).await.unwrap(), 0.0);
+    /// # });
+    /// ```
     pub async fn get_suppression_factor(&self, key: &RedisKey) -> Result<f64, TrypemaError> {
         self.send_epoch_change_if_needed();
 
@@ -316,6 +328,23 @@ impl SuppressedHybridRateLimiter {
     ///
     /// The total observed counter is always incremented. If `is_allowed` is `false`,
     /// the declined counter is also incremented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// // Under limit → Allowed
+    /// assert!(matches!(
+    ///     rl.hybrid().suppressed().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub async fn inc(
         &self,
         key: &RedisKey,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use local::*;
 /// Redis-backed distributed rate limiter implementations.
 ///
 /// Provides [`RedisRateLimiterProvider`], which executes
-/// all operations as atomic Lua scripts against Redis 6.2+. Each `inc()` or `is_allowed()`
+/// all operations as atomic Lua scripts against Redis 7.2+. Each `inc()` or `is_allowed()`
 /// call results in one Redis round-trip.
 #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
@@ -49,3 +49,6 @@ pub use common::{
 
 #[cfg(test)]
 mod tests;
+
+#[doc(hidden)]
+pub mod __doctest_helpers;

--- a/src/local/absolute_local_rate_limiter.rs
+++ b/src/local/absolute_local_rate_limiter.rs
@@ -81,74 +81,15 @@ impl RateLimitSeries {
 ///
 /// # Examples
 ///
-/// ```no_run
-/// use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-/// use trypema::local::LocalRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::redis::RedisRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::hybrid::SyncIntervalMs;
-/// #
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #     let sync_interval_ms = SyncIntervalMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #         redis: RedisRateLimiterOptions {
-/// #             connection_manager: todo!(),
-/// #             prefix: None,
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #             sync_interval_ms,
-/// #         },
-/// #     }
-/// # }
-/// #
-/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #     }
-/// # }
+/// ```
+/// # let rl = trypema::__doctest_helpers::rate_limiter();
+/// use trypema::{RateLimit, RateLimitDecision};
 ///
-/// let rl = RateLimiter::new(options());
 /// let limiter = rl.local().absolute();
+/// let rate = RateLimit::try_from(10.0).unwrap();
 ///
-/// let rate = RateLimit::try_from(10.0).unwrap(); // 10 req/s
-///
-/// // First request for key: allowed and rate limit stored
-/// assert!(matches!(
-///     limiter.inc("user_123", &rate, 1),
-///     RateLimitDecision::Allowed
-/// ));
-///
-/// // Check without incrementing
-/// assert!(matches!(
-///     limiter.is_allowed("user_123"),
-///     RateLimitDecision::Allowed
-/// ));
+/// assert!(matches!(limiter.inc("user_123", &rate, 1), RateLimitDecision::Allowed));
+/// assert!(matches!(limiter.is_allowed("user_123"), RateLimitDecision::Allowed));
 /// ```
 #[derive(Debug)]
 pub struct AbsoluteLocalRateLimiter {
@@ -217,77 +158,18 @@ impl AbsoluteLocalRateLimiter {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// # use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-    /// # use trypema::local::LocalRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::redis::RedisRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::hybrid::SyncIntervalMs;
-    /// #
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #     let sync_interval_ms = SyncIntervalMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #         redis: RedisRateLimiterOptions {
-    /// #             connection_manager: todo!(),
-    /// #             prefix: None,
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #             sync_interval_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # let rl = RateLimiter::new(options());
-    /// # let limiter = rl.local().absolute();
+    /// ```
+    /// # let rl = trypema::__doctest_helpers::rate_limiter();
+    /// use trypema::{RateLimit, RateLimitDecision};
+    ///
+    /// let limiter = rl.local().absolute();
     /// let rate = RateLimit::try_from(10.0).unwrap();
     ///
     /// // Single request
-    /// match limiter.inc("user_123", &rate, 1) {
-    ///     RateLimitDecision::Allowed => println!("Request allowed"),
-    ///     RateLimitDecision::Rejected { retry_after_ms, .. } => {
-    ///         println!("Rate limited, retry in {}ms", retry_after_ms);
-    ///     }
-    ///     _ => unreachable!(),
-    /// }
+    /// assert!(matches!(limiter.inc("user_123", &rate, 1), RateLimitDecision::Allowed));
     ///
-    /// // Batch of 10 requests
-    /// match limiter.inc("user_456", &rate, 10) {
-    ///     RateLimitDecision::Allowed => println!("Batch allowed"),
-    ///     RateLimitDecision::Rejected { .. } => println!("Batch rejected"),
-    ///     _ => unreachable!(),
-    /// }
+    /// // Batch of 10
+    /// assert!(matches!(limiter.inc("user_456", &rate, 10), RateLimitDecision::Allowed));
     /// ```
     pub fn inc(&self, key: &str, rate_limit: &RateLimit, count: u64) -> RateLimitDecision {
         let is_allowed = self.is_allowed(key);
@@ -369,77 +251,19 @@ impl AbsoluteLocalRateLimiter {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// # use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-    /// # use trypema::local::LocalRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::redis::RedisRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::hybrid::SyncIntervalMs;
-    /// #
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #     let sync_interval_ms = SyncIntervalMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #         redis: RedisRateLimiterOptions {
-    /// #             connection_manager: todo!(),
-    /// #             prefix: None,
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #             sync_interval_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # let rl = RateLimiter::new(options());
-    /// # let limiter = rl.local().absolute();
-    /// # let rate = RateLimit::try_from(10.0).unwrap();
-    /// // Check before expensive operation
-    /// match limiter.is_allowed("user_123") {
-    ///     RateLimitDecision::Allowed => {
-    ///         // Do expensive work, then record
-    ///         // expensive_operation();
-    ///         limiter.inc("user_123", &rate, 1);
-    ///     }
-    ///     RateLimitDecision::Rejected { retry_after_ms, .. } => {
-    ///         println!("Rate limited, retry in {}ms", retry_after_ms);
-    ///     }
-    ///     _ => unreachable!(),
-    /// }
+    /// ```
+    /// # let rl = trypema::__doctest_helpers::rate_limiter();
+    /// use trypema::{RateLimit, RateLimitDecision};
     ///
-    /// // Preview for metrics (doesn't affect state)
-    /// if matches!(limiter.is_allowed("api_endpoint"), RateLimitDecision::Rejected { .. }) {
-    ///     // metrics.increment("rate_limit.at_capacity");
+    /// let limiter = rl.local().absolute();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    ///
+    /// // Unknown key → always allowed
+    /// assert!(matches!(limiter.is_allowed("new_key"), RateLimitDecision::Allowed));
+    ///
+    /// // Check before recording
+    /// if matches!(limiter.is_allowed("user_123"), RateLimitDecision::Allowed) {
+    ///     limiter.inc("user_123", &rate, 1);
     /// }
     /// ```
     pub fn is_allowed(&self, key: &str) -> RateLimitDecision {

--- a/src/local/local_rate_limiter_provider.rs
+++ b/src/local/local_rate_limiter_provider.rs
@@ -42,7 +42,7 @@ use crate::{
 ///     suppression_factor_cache_ms: SuppressionFactorCacheMs::default(),
 /// };
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LocalRateLimiterOptions {
     /// Sliding window duration for admission decisions.
     ///

--- a/src/local/local_rate_limiter_provider.rs
+++ b/src/local/local_rate_limiter_provider.rs
@@ -5,12 +5,8 @@ use crate::{
 
 /// Configuration for local (in-process) rate limiters.
 ///
-/// Configures the sliding window, bucket coalescing, and hard limit behavior
-/// for both absolute and suppressed strategies.
-///
-/// # Field Descriptions
-///
-/// See individual field documentation for detailed information on each parameter.
+/// Controls the shared settings used by [`AbsoluteLocalRateLimiter`] and
+/// [`SuppressedLocalRateLimiter`].
 ///
 /// # Examples
 ///
@@ -18,7 +14,8 @@ use crate::{
 /// use trypema::{HardLimitFactor, RateGroupSizeMs, SuppressionFactorCacheMs, WindowSizeSeconds};
 /// use trypema::local::LocalRateLimiterOptions;
 ///
-/// // Recommended defaults for most use cases
+/// let defaults = LocalRateLimiterOptions::default();
+///
 /// let options = LocalRateLimiterOptions {
 ///     window_size_seconds: WindowSizeSeconds::try_from(60).unwrap(),   // 60s sliding window
 ///     rate_group_size_ms: RateGroupSizeMs::try_from(10).unwrap(),      // 10ms coalescing
@@ -86,8 +83,8 @@ pub struct LocalRateLimiterOptions {
 
 /// Provider for in-process rate limiting strategies.
 ///
-/// Provides access to multiple local rate limiting strategies that share the same
-/// configuration but implement different enforcement policies.
+/// Exposes [`AbsoluteLocalRateLimiter`] and [`SuppressedLocalRateLimiter`] under one shared
+/// configuration.
 ///
 /// # Strategies
 ///
@@ -100,63 +97,11 @@ pub struct LocalRateLimiterOptions {
 ///
 /// # Examples
 ///
-/// ```no_run
-/// use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-/// use trypema::local::LocalRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::redis::RedisRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::hybrid::SyncIntervalMs;
-/// #
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #     let sync_interval_ms = SyncIntervalMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #         redis: RedisRateLimiterOptions {
-/// #             connection_manager: todo!(),
-/// #             prefix: None,
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #             sync_interval_ms,
-/// #         },
-/// #     }
-/// # }
-/// #
-/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #     }
-/// # }
-///
-/// let rl = RateLimiter::new(options());
+/// ```
+/// # let rl = trypema::__doctest_helpers::rate_limiter();
+/// use trypema::RateLimit;
 ///
 /// let rate = RateLimit::try_from(10.0).unwrap();
-///
-/// // Choose strategy based on requirements
 /// let abs_decision = rl.local().absolute().inc("user_123", &rate, 1);
 /// let sup_decision = rl.local().suppressed().inc("user_456", &rate, 1);
 /// ```
@@ -183,60 +128,13 @@ impl LocalRateLimiterProvider {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// # use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-    /// # use trypema::local::LocalRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::redis::RedisRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::hybrid::SyncIntervalMs;
-    /// #
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #     let sync_interval_ms = SyncIntervalMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #         redis: RedisRateLimiterOptions {
-    /// #             connection_manager: todo!(),
-    /// #             prefix: None,
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #             sync_interval_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// # let rl = RateLimiter::new(options());
+    /// ```
+    /// # let rl = trypema::__doctest_helpers::rate_limiter();
+    /// use trypema::{RateLimit, RateLimitDecision};
+    ///
     /// let rate = RateLimit::try_from(10.0).unwrap();
     /// let decision = rl.local().absolute().inc("user_123", &rate, 1);
+    /// assert!(matches!(decision, RateLimitDecision::Allowed));
     /// ```
     pub fn absolute(&self) -> &AbsoluteLocalRateLimiter {
         &self.absolute
@@ -254,64 +152,17 @@ impl LocalRateLimiterProvider {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// # use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-    /// # use trypema::local::LocalRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::redis::RedisRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::hybrid::SyncIntervalMs;
-    /// #
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #     let sync_interval_ms = SyncIntervalMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #         redis: RedisRateLimiterOptions {
-    /// #             connection_manager: todo!(),
-    /// #             prefix: None,
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #             sync_interval_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// # let rl = RateLimiter::new(options());
+    /// ```
+    /// # let rl = trypema::__doctest_helpers::rate_limiter();
+    /// use trypema::{RateLimit, RateLimitDecision};
+    ///
     /// let rate = RateLimit::try_from(10.0).unwrap();
     /// match rl.local().suppressed().inc("user_123", &rate, 1) {
     ///     RateLimitDecision::Suppressed { is_allowed, suppression_factor } => {
-    ///         println!("Suppression: {}, allowed: {}", suppression_factor, is_allowed);
+    ///         println!("suppression: {suppression_factor}, allowed: {is_allowed}");
     ///     }
-    ///     _ => {}
+    ///     RateLimitDecision::Allowed => {}
+    ///     _ => unreachable!(),
     /// }
     /// ```
     pub fn suppressed(&self) -> &SuppressedLocalRateLimiter {

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -94,9 +94,9 @@
 //! ```
 
 mod absolute_local_rate_limiter;
-pub use absolute_local_rate_limiter::*;
 #[cfg(test)]
 pub(crate) use absolute_local_rate_limiter::RateLimitSeries as AbsoluteRateLimitSeries;
+pub use absolute_local_rate_limiter::*;
 
 mod local_rate_limiter_provider;
 pub use local_rate_limiter_provider::*;

--- a/src/local/suppressed_local_rate_limiter.rs
+++ b/src/local/suppressed_local_rate_limiter.rs
@@ -109,76 +109,19 @@ impl RateLimitSeries {
 ///
 /// # Examples
 ///
-/// ```no_run
-/// use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::hybrid::SyncIntervalMs;
-/// use trypema::local::LocalRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::redis::RedisRateLimiterOptions;
-/// #
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::try_from(1.5).unwrap();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #     let sync_interval_ms = SyncIntervalMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #         redis: RedisRateLimiterOptions {
-/// #             connection_manager: todo!(),
-/// #             prefix: None,
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #             sync_interval_ms,
-/// #         },
-/// #     }
-/// # }
-/// #
-/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::try_from(1.5).unwrap();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #     }
-/// # }
+/// ```
+/// # let rl = trypema::__doctest_helpers::rate_limiter();
+/// use trypema::{RateLimit, RateLimitDecision};
 ///
-/// let rl = RateLimiter::new(options());
 /// let limiter = rl.local().suppressed();
-///
-/// let rate = RateLimit::try_from(10.0).unwrap(); // 10 req/s target, 15 req/s hard limit
+/// let rate = RateLimit::try_from(10.0).unwrap();
 ///
 /// match limiter.inc("user_123", &rate, 1) {
-///     RateLimitDecision::Allowed => {
-///         // Below capacity, proceed normally
+///     RateLimitDecision::Allowed => {}
+///     RateLimitDecision::Suppressed { is_allowed, suppression_factor } => {
+///         println!("suppression: {suppression_factor:.2}, allowed: {is_allowed}");
 ///     }
-///     RateLimitDecision::Suppressed { is_allowed: true, suppression_factor } => {
-///         // At capacity, this request allowed (but suppression active)
-///         println!("Allowed with {}% suppression", suppression_factor * 100.0);
-///     }
-///     RateLimitDecision::Suppressed { is_allowed: false, suppression_factor } => {
-///         // At capacity, this request suppressed
-///         println!("Suppressed ({}% rate)", suppression_factor * 100.0);
-///     }
-///     RateLimitDecision::Rejected { .. } => unreachable!("local suppressed limiter never rejects"),
+///     RateLimitDecision::Rejected { .. } => unreachable!(),
 /// }
 /// ```
 #[derive(Debug)]
@@ -239,6 +182,19 @@ impl SuppressedLocalRateLimiter {
     ///
     /// Same best-effort semantics as the absolute strategy. Under concurrent load, multiple
     /// threads may proceed simultaneously, causing temporary overshoot. This is by design.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # let rl = trypema::__doctest_helpers::rate_limiter();
+    /// use trypema::{RateLimit, RateLimitDecision};
+    ///
+    /// let limiter = rl.local().suppressed();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    ///
+    /// // Under limit → Allowed
+    /// assert!(matches!(limiter.inc("user_123", &rate, 1), RateLimitDecision::Allowed));
+    /// ```
     pub fn inc(&self, key: &str, rate_limit: &RateLimit, count: u64) -> RateLimitDecision {
         let mut rng = |p: f64| rand::random_bool(p);
         self.inc_with_rng(key, rate_limit, count, &mut rng)
@@ -443,6 +399,16 @@ impl SuppressedLocalRateLimiter {
     ///
     /// **Caching:** Returns the cached value if it was computed within `suppression_factor_cache_ms`.
     /// Otherwise, evicts expired buckets and recomputes the factor from the current sliding window.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # let rl = trypema::__doctest_helpers::rate_limiter();
+    /// let limiter = rl.local().suppressed();
+    ///
+    /// // No state yet → 0.0 (no suppression)
+    /// assert_eq!(limiter.get_suppression_factor("unknown_key"), 0.0);
+    /// ```
     pub fn get_suppression_factor(&self, key: &str) -> f64 {
         self.remove_expired_buckets(key);
         self.get_suppression_factor_without_bucket_expire(key)

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,74 +1,23 @@
 //! Top-level rate limiter facade.
 //!
-//! This module provides [`RateLimiter`], the main entry point for the Trypema library.
-//! A single `RateLimiter` instance gives access to all three providers:
+//! [`RateLimiter`] is the main entry point for Trypema. One limiter gives you access to:
 //!
 //! - [`LocalRateLimiterProvider`] via [`RateLimiter::local()`] — in-process rate limiting
-//! - [`RedisRateLimiterProvider`] via [`RateLimiter::redis()`] — distributed rate limiting (Redis 6.2+)
+//! - [`RedisRateLimiterProvider`] via [`RateLimiter::redis()`] — best-effort distributed
+//!   limiting backed by Redis 7.2+
 //! - [`HybridRateLimiterProvider`] via [`RateLimiter::hybrid()`] — local fast-path with periodic Redis sync
 //!
-//! `RateLimiter` is thread-safe and designed to be wrapped in `Arc<RateLimiter>`. The
-//! optional cleanup loop uses `Weak` references internally, so dropping all `Arc` references
-//! automatically stops background tasks without risk of keeping the limiter alive.
+//! `RateLimiter` is thread-safe and designed to be shared behind [`Arc`]. The optional cleanup
+//! loop keeps only a `Weak` reference internally, so dropping the last [`Arc`] cleanly stops the
+//! background work.
 //!
 //! # Examples
 //!
-//! ```no_run
+//! ```
 //! use std::sync::Arc;
-//! use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-//! use trypema::local::LocalRateLimiterOptions;
-//! # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-//! # use trypema::redis::RedisRateLimiterOptions;
-//! # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-//! # use trypema::hybrid::SyncIntervalMs;
-//! #
-//! # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-//! # fn options() -> RateLimiterOptions {
-//! #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-//! #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-//! #     let hard_limit_factor = HardLimitFactor::default();
-//! #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-//! #     let sync_interval_ms = SyncIntervalMs::default();
-//! #
-//! #     RateLimiterOptions {
-//! #         local: LocalRateLimiterOptions {
-//! #             window_size_seconds,
-//! #             rate_group_size_ms,
-//! #             hard_limit_factor,
-//! #             suppression_factor_cache_ms,
-//! #         },
-//! #         redis: RedisRateLimiterOptions {
-//! #             connection_manager: todo!(),
-//! #             prefix: None,
-//! #             window_size_seconds,
-//! #             rate_group_size_ms,
-//! #             hard_limit_factor,
-//! #             suppression_factor_cache_ms,
-//! #             sync_interval_ms,
-//! #         },
-//! #     }
-//! # }
-//! #
-//! # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-//! # fn options() -> RateLimiterOptions {
-//! #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-//! #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-//! #     let hard_limit_factor = HardLimitFactor::default();
-//! #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-//! #
-//! #     RateLimiterOptions {
-//! #         local: LocalRateLimiterOptions {
-//! #             window_size_seconds,
-//! #             rate_group_size_ms,
-//! #             hard_limit_factor,
-//! #             suppression_factor_cache_ms,
-//! #         },
-//! #     }
-//! # }
+//! use trypema::RateLimit;
 //!
-//! let rl = Arc::new(RateLimiter::new(options()));
-//!
-//! // Start background cleanup (optional but recommended)
+//! let rl = trypema::__doctest_helpers::rate_limiter();
 //! rl.run_cleanup_loop();
 //!
 //! let rate = RateLimit::try_from(10.0).unwrap();
@@ -102,65 +51,29 @@ use redis::aio::ConnectionManager;
 
 /// Configuration for [`RateLimiter`].
 ///
-/// Configures both local and Redis providers. If Redis features are disabled,
-/// only `local` is required.
+/// Bundles the local configuration and, when enabled, the Redis-backed configuration used by both
+/// the Redis and hybrid providers.
+///
+/// Use [`LocalRateLimiterOptions`] to configure the local provider and `RedisRateLimiterOptions`
+/// to configure the Redis and hybrid providers when Redis features are enabled.
 ///
 /// # Examples
 ///
-/// Local-only configuration:
-/// ```no_run
+/// ```
+/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+/// # {
 /// use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
 /// use trypema::local::LocalRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::redis::RedisRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::hybrid::SyncIntervalMs;
-/// #
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #     let sync_interval_ms = SyncIntervalMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #         redis: RedisRateLimiterOptions {
-/// #             connection_manager: todo!(),
-/// #             prefix: None,
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #             sync_interval_ms,
-/// #         },
-/// #     }
-/// # }
-/// #
-/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #     }
-/// # }
 ///
-/// let options = options();
+/// let _options = RateLimiterOptions {
+///     local: LocalRateLimiterOptions {
+///         window_size_seconds: WindowSizeSeconds::try_from(60).unwrap(),
+///         rate_group_size_ms: RateGroupSizeMs::try_from(10).unwrap(),
+///         hard_limit_factor: HardLimitFactor::try_from(1.5).unwrap(),
+///         suppression_factor_cache_ms: SuppressionFactorCacheMs::default(),
+///     },
+/// };
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 pub struct RateLimiterOptions {
@@ -189,11 +102,13 @@ impl Default for RateLimiterOptions {
 
 /// Primary rate limiter facade.
 ///
-/// Provides access to all rate limiting providers and strategies through a single instance:
+/// A single facade for local and optional Redis-backed rate limiting.
+///
+/// `RateLimiter` exposes:
 ///
 /// - **Local provider** (`rl.local()`) — in-process, sub-microsecond latency
-/// - **Redis provider** (`rl.redis()`) — distributed via atomic Lua scripts
-/// - **Hybrid provider** (`rl.hybrid()`) — local fast-path with periodic Redis sync
+/// - **Redis provider** (`rl.redis()`) — best-effort distributed limiting via atomic Lua scripts
+/// - **Hybrid provider** (`rl.hybrid()`) — best-effort distributed limiting with a local fast path
 ///
 /// Each provider exposes two strategies: **absolute** (deterministic sliding-window) and
 /// **suppressed** (probabilistic degradation).
@@ -206,61 +121,10 @@ impl Default for RateLimiterOptions {
 ///
 /// # Examples
 ///
-/// ```no_run
-/// use std::sync::Arc;
-/// use trypema::{RateLimit, RateLimiter, RateLimiterOptions};
-/// use trypema::{HardLimitFactor, RateGroupSizeMs, SuppressionFactorCacheMs, WindowSizeSeconds};
-/// use trypema::local::LocalRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::redis::RedisRateLimiterOptions;
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # use trypema::hybrid::SyncIntervalMs;
-/// #
-/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #     let sync_interval_ms = SyncIntervalMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #         redis: RedisRateLimiterOptions {
-/// #             connection_manager: todo!(),
-/// #             prefix: None,
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #             sync_interval_ms,
-/// #         },
-/// #     }
-/// # }
-/// #
-/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-/// # fn options() -> RateLimiterOptions {
-/// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-/// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-/// #     let hard_limit_factor = HardLimitFactor::default();
-/// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// #
-/// #     RateLimiterOptions {
-/// #         local: LocalRateLimiterOptions {
-/// #             window_size_seconds,
-/// #             rate_group_size_ms,
-/// #             hard_limit_factor,
-/// #             suppression_factor_cache_ms,
-/// #         },
-/// #     }
-/// # }
+/// ```
+/// use trypema::RateLimit;
 ///
-/// let rl = Arc::new(RateLimiter::new(options()));
+/// let rl = trypema::__doctest_helpers::rate_limiter();
 /// rl.run_cleanup_loop();
 ///
 /// let rate = RateLimit::try_from(5.0).unwrap();
@@ -286,61 +150,12 @@ impl Drop for RateLimiter {
 impl RateLimiter {
     /// Create a new rate limiter with the given configuration.
     ///
+    /// Prefer [`RateLimiter::builder()`] for a more ergonomic construction with defaults.
+    ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::hybrid::SyncIntervalMs;
-    /// use trypema::local::LocalRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::redis::RedisRateLimiterOptions;
-    /// #
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #     let sync_interval_ms = SyncIntervalMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #         redis: RedisRateLimiterOptions {
-    /// #             connection_manager: todo!(),
-    /// #             prefix: None,
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #             sync_interval_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    ///
-    /// let rl = RateLimiter::new(options());
+    /// ```
+    /// let rl = trypema::__doctest_helpers::rate_limiter();
     /// ```
     pub fn new(options: RateLimiterOptions) -> Self {
         Self {
@@ -487,49 +302,20 @@ impl RateLimiter {
 
     /// Access the Redis provider for distributed rate limiting.
     ///
-    /// Requires Redis 6.2+ and one of the Redis features (`redis-tokio` or `redis-smol`).
+    /// Requires Redis 7.2+ and one of the runtime features (`redis-tokio` or `redis-smol`).
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// # async fn example() -> Result<(), trypema::TrypemaError> {
-    /// use trypema::{
-    ///     HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimiter, RateLimiterOptions,
-    ///     SuppressionFactorCacheMs, WindowSizeSeconds,
-    /// };
-    /// use trypema::hybrid::SyncIntervalMs;
-    /// use trypema::local::LocalRateLimiterOptions;
-    /// use trypema::redis::{RedisKey, RedisRateLimiterOptions};
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
     ///
-    /// let window_size_seconds = WindowSizeSeconds::try_from(60)?;
-    /// let rate_group_size_ms = RateGroupSizeMs::try_from(10)?;
-    /// let hard_limit_factor = HardLimitFactor::default();
-    /// let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// let sync_interval_ms = SyncIntervalMs::default();
-    ///
-    /// let rl = RateLimiter::new(RateLimiterOptions {
-    ///     local: LocalRateLimiterOptions {
-    ///         window_size_seconds,
-    ///         rate_group_size_ms,
-    ///         hard_limit_factor,
-    ///         suppression_factor_cache_ms,
-    ///     },
-    ///     redis: RedisRateLimiterOptions {
-    ///         connection_manager: todo!("create redis::aio::ConnectionManager"),
-    ///         prefix: None,
-    ///         window_size_seconds,
-    ///         rate_group_size_ms,
-    ///         hard_limit_factor,
-    ///         suppression_factor_cache_ms,
-    ///         sync_interval_ms,
-    ///     },
-    /// });
-    ///
-    /// let key = RedisKey::try_from("user_123".to_string())?;
-    /// let rate = RateLimit::try_from(10.0)?;
-    ///
-    /// let _decision = rl.redis().absolute().inc(&key, &rate, 1).await?;
-    /// # Ok(()) }
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// let decision = rl.redis().absolute().inc(&key, &rate, 1).await.unwrap();
+    /// assert!(matches!(decision, RateLimitDecision::Allowed));
+    /// # });
     /// ```
     #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
@@ -544,22 +330,22 @@ impl RateLimiter {
     /// compared to using [`RateLimiter::redis`], at the cost of some additional approximation due to
     /// sync lag.
     ///
-    /// Requires Redis 6.2+ and one of the Redis features (`redis-tokio` or `redis-smol`).
+    /// Requires Redis 7.2+ and one of the runtime features (`redis-tokio` or `redis-smol`).
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// # async fn example() -> Result<(), trypema::TrypemaError> {
-    /// use trypema::{RateLimit, RateLimiter};
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
     /// use trypema::redis::RedisKey;
     ///
-    /// let rl: RateLimiter = todo!("construct RateLimiter with RedisRateLimiterOptions");
-    /// let key = RedisKey::try_from("user_123".to_string())?;
-    /// let rate = RateLimit::try_from(10.0)?;
-    ///
-    /// let _ = rl.hybrid().absolute().inc(&key, &rate, 1).await?;
-    /// let _ = rl.hybrid().suppressed().inc(&key, &rate, 1).await?;
-    /// # Ok(()) }
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// assert!(matches!(
+    ///     rl.hybrid().absolute().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
     /// ```
     #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
@@ -571,60 +357,13 @@ impl RateLimiter {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// # use trypema::{HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimiter, RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds};
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::hybrid::SyncIntervalMs;
-    /// # use trypema::local::LocalRateLimiterOptions;
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # use trypema::redis::RedisRateLimiterOptions;
-    /// #
-    /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #     let sync_interval_ms = SyncIntervalMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #         redis: RedisRateLimiterOptions {
-    /// #             connection_manager: todo!(),
-    /// #             prefix: None,
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #             sync_interval_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// #
-    /// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
-    /// # fn options() -> RateLimiterOptions {
-    /// #     let window_size_seconds = WindowSizeSeconds::try_from(60).unwrap();
-    /// #     let rate_group_size_ms = RateGroupSizeMs::try_from(10).unwrap();
-    /// #     let hard_limit_factor = HardLimitFactor::default();
-    /// #     let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-    /// #
-    /// #     RateLimiterOptions {
-    /// #         local: LocalRateLimiterOptions {
-    /// #             window_size_seconds,
-    /// #             rate_group_size_ms,
-    /// #             hard_limit_factor,
-    /// #             suppression_factor_cache_ms,
-    /// #         },
-    /// #     }
-    /// # }
-    /// # let rl = RateLimiter::new(options());
+    /// ```
+    /// # let rl = trypema::__doctest_helpers::rate_limiter();
+    /// use trypema::{RateLimit, RateLimitDecision};
+    ///
     /// let rate = RateLimit::try_from(10.0).unwrap();
     /// let decision = rl.local().absolute().inc("user_123", &rate, 1);
+    /// assert!(matches!(decision, RateLimitDecision::Allowed));
     /// ```
     pub fn local(&self) -> &LocalRateLimiterProvider {
         &self.local
@@ -633,33 +372,73 @@ impl RateLimiter {
 
 /// Builder for [`RateLimiter`].
 ///
-/// Construct via [`RateLimiter::builder()`]. All fields have sensible defaults derived
-/// from each type's own [`Default`] implementation, so changing a type's default
-/// automatically propagates here without code changes.
+/// A fluent builder for configuring and constructing a [`RateLimiter`].
 ///
-/// # Without Redis features
+/// Without Redis features, start with `RateLimiterBuilder::default()` or
+/// [`RateLimiter::builder`]. With `redis-tokio` or `redis-smol`, start with
+/// [`RateLimiter::builder`] and provide a Redis `connection_manager`.
 ///
-/// ```no_run
-/// use trypema::RateLimiter;
+/// [`RateLimiterBuilder::build`] returns an [`Arc<RateLimiter>`] and starts the cleanup loop
+/// automatically. If you construct a limiter manually with [`RateLimiter::new`], you start
+/// cleanup yourself with [`RateLimiter::run_cleanup_loop`].
 ///
-/// let rl = RateLimiter::builder()
+/// # Examples
+///
+/// Local-only builder with a few optional overrides:
+///
+/// ```
+/// # #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+/// # {
+/// use trypema::{RateLimit, RateLimitDecision, RateLimiterBuilder};
+///
+/// let rl = RateLimiterBuilder::default()
 ///     .window_size_seconds(60)
+///     .rate_group_size_ms(10)
+///     .hard_limit_factor(1.5)
 ///     .build()
 ///     .unwrap();
+///
+/// let rate = RateLimit::try_from(5.0).unwrap();
+/// assert!(matches!(
+///     rl.local().absolute().inc("user_123", &rate, 1),
+///     RateLimitDecision::Allowed
+/// ));
+/// # }
 /// ```
 ///
-/// # With Redis features
+/// Redis-enabled builder:
 ///
-/// ```no_run
+/// ```
 /// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
-/// # async fn example() {
-/// # let connection_manager: redis::aio::ConnectionManager = todo!();
-/// use trypema::RateLimiter;
+/// # {
+/// # trypema::__doctest_helpers::with_redis_rate_limiter(|_rl| async move {
+/// use trypema::{RateLimit, RateLimitDecision, RateLimiter};
+/// use trypema::redis::RedisKey;
+///
+/// let url = std::env::var("REDIS_URL")
+///     .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+/// let connection_manager = redis::Client::open(url)
+///     .unwrap()
+///     .get_connection_manager()
+///     .await
+///     .unwrap();
 ///
 /// let rl = RateLimiter::builder(connection_manager)
 ///     .window_size_seconds(60)
+///     .rate_group_size_ms(10)
+///     .redis_prefix(RedisKey::new_or_panic("docs".to_string()))
+///     .sync_interval_ms(10)
 ///     .build()
 ///     .unwrap();
+///
+/// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+/// let rate = RateLimit::try_from(5.0).unwrap();
+/// assert!(matches!(
+///     rl.redis().absolute().inc(&key, &rate, 1).await.unwrap(),
+///     RateLimitDecision::Allowed
+/// ));
+/// # let _ = _rl;
+/// # });
 /// # }
 /// ```
 pub struct RateLimiterBuilder {
@@ -679,6 +458,8 @@ pub struct RateLimiterBuilder {
 
 #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
 impl Default for RateLimiterBuilder {
+    /// Create a local-only [`RateLimiterBuilder`] seeded from the defaults of the validated
+    /// option types such as [`WindowSizeSeconds`] and [`RateGroupSizeMs`].
     fn default() -> Self {
         Self {
             window_size_seconds: *WindowSizeSeconds::default(),
@@ -694,6 +475,8 @@ impl Default for RateLimiterBuilder {
 #[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
 impl RateLimiter {
     /// Create a builder for [`RateLimiter`] with sensible defaults.
+    ///
+    /// For local-only builds this is equivalent to [`RateLimiterBuilder::default`].
     pub fn builder() -> RateLimiterBuilder {
         RateLimiterBuilder::default()
     }
@@ -723,32 +506,42 @@ impl RateLimiter {
     /// Create a builder for [`RateLimiter`].
     ///
     /// The `connection_manager` is required because it has no default.
-    /// All other options default to sensible values.
+    /// All other options default to sensible values. Redis-only builder methods such as
+    /// [`RateLimiterBuilder::redis_prefix`] and [`RateLimiterBuilder::sync_interval_ms`] are only
+    /// available with `redis-tokio` or `redis-smol`.
     pub fn builder(connection_manager: ConnectionManager) -> RateLimiterBuilder {
         RateLimiterBuilder::new_with_connection_manager(connection_manager)
     }
 }
 
 impl RateLimiterBuilder {
-    /// Set the sliding window duration in seconds. Default: [`WindowSizeSeconds::default()`].
+    /// Set the sliding window duration in seconds.
+    ///
+    /// Default: [`WindowSizeSeconds::default()`].
     pub fn window_size_seconds(mut self, v: u64) -> Self {
         self.window_size_seconds = v;
         self
     }
 
-    /// Set the bucket coalescing interval in milliseconds. Default: [`RateGroupSizeMs::default()`].
+    /// Set the bucket coalescing interval in milliseconds.
+    ///
+    /// Default: [`RateGroupSizeMs::default()`].
     pub fn rate_group_size_ms(mut self, v: u64) -> Self {
         self.rate_group_size_ms = v;
         self
     }
 
-    /// Set the hard cutoff multiplier for the suppressed strategy. Default: [`HardLimitFactor::default()`].
+    /// Set the hard cutoff multiplier for the suppressed strategy.
+    ///
+    /// Default: [`HardLimitFactor::default()`].
     pub fn hard_limit_factor(mut self, v: f64) -> Self {
         self.hard_limit_factor = v;
         self
     }
 
-    /// Set the suppression factor cache duration in milliseconds. Default: [`SuppressionFactorCacheMs::default()`].
+    /// Set the suppression factor cache duration in milliseconds.
+    ///
+    /// Default: [`SuppressionFactorCacheMs::default()`].
     pub fn suppression_factor_cache_ms(mut self, v: u64) -> Self {
         self.suppression_factor_cache_ms = v;
         self
@@ -784,7 +577,8 @@ impl RateLimiterBuilder {
 
     /// Build the [`RateLimiter`], wrapped in [`Arc`], with the cleanup loop already running.
     ///
-    /// Returns `Err` if any option value fails validation.
+    /// Returns `Err` if any option value fails validation. For manual construction without
+    /// automatic cleanup startup, see [`RateLimiter::new`].
     pub fn build(self) -> Result<Arc<RateLimiter>, TrypemaError> {
         let options = RateLimiterOptions {
             local: LocalRateLimiterOptions {

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -85,11 +85,20 @@ use std::{
 
 #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
 use crate::hybrid::HybridRateLimiterProvider;
-use crate::{LocalRateLimiterOptions, LocalRateLimiterProvider};
+use crate::{
+    HardLimitFactor, LocalRateLimiterOptions, LocalRateLimiterProvider, RateGroupSizeMs,
+    SuppressionFactorCacheMs, TrypemaError, WindowSizeSeconds,
+};
 
 #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
-use crate::redis::{RedisRateLimiterOptions, RedisRateLimiterProvider};
+use crate::redis::{RedisKey, RedisRateLimiterOptions, RedisRateLimiterProvider};
+
+#[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+use crate::hybrid::SyncIntervalMs;
+
+#[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+use redis::aio::ConnectionManager;
 
 /// Configuration for [`RateLimiter`].
 ///
@@ -163,6 +172,19 @@ pub struct RateLimiterOptions {
     /// Only available with `redis-tokio` or `redis-smol` features.
     #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
     pub redis: RedisRateLimiterOptions,
+}
+
+/// Default configuration for [`RateLimiterOptions`].
+///
+/// Only available when Redis features are disabled. When Redis features are enabled,
+/// `RateLimiterOptions` requires a `ConnectionManager` which has no meaningful default.
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+impl Default for RateLimiterOptions {
+    fn default() -> Self {
+        Self {
+            local: LocalRateLimiterOptions::default(),
+        }
+    }
 }
 
 /// Primary rate limiter facade.
@@ -253,6 +275,12 @@ pub struct RateLimiter {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
     hybrid: HybridRateLimiterProvider,
     is_loop_running: AtomicBool,
+}
+
+impl Drop for RateLimiter {
+    fn drop(&mut self) {
+        self.stop_cleanup_loop();
+    }
 }
 
 impl RateLimiter {
@@ -453,7 +481,7 @@ impl RateLimiter {
     /// This method is idempotent and safe to call multiple times.
     ///
     /// Stopping is best-effort and asynchronous: background tasks will exit on their next check/tick.
-    pub fn stop_cleanup_loop(self: &Arc<Self>) {
+    pub fn stop_cleanup_loop(&self) {
         self.is_loop_running.store(false, Ordering::SeqCst);
     } // end method stop_cleanup_loop
 
@@ -600,5 +628,188 @@ impl RateLimiter {
     /// ```
     pub fn local(&self) -> &LocalRateLimiterProvider {
         &self.local
+    }
+}
+
+/// Builder for [`RateLimiter`].
+///
+/// Construct via [`RateLimiter::builder()`]. All fields have sensible defaults derived
+/// from each type's own [`Default`] implementation, so changing a type's default
+/// automatically propagates here without code changes.
+///
+/// # Without Redis features
+///
+/// ```no_run
+/// use trypema::RateLimiter;
+///
+/// let rl = RateLimiter::builder()
+///     .window_size_seconds(60)
+///     .build()
+///     .unwrap();
+/// ```
+///
+/// # With Redis features
+///
+/// ```no_run
+/// # #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+/// # async fn example() {
+/// # let connection_manager: redis::aio::ConnectionManager = todo!();
+/// use trypema::RateLimiter;
+///
+/// let rl = RateLimiter::builder(connection_manager)
+///     .window_size_seconds(60)
+///     .build()
+///     .unwrap();
+/// # }
+/// ```
+pub struct RateLimiterBuilder {
+    window_size_seconds: u64,
+    rate_group_size_ms: u64,
+    hard_limit_factor: f64,
+    suppression_factor_cache_ms: u64,
+    stale_after_ms: u64,
+    cleanup_interval_ms: u64,
+    #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+    connection_manager: ConnectionManager,
+    #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+    redis_prefix: Option<RedisKey>,
+    #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+    sync_interval_ms: u64,
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+impl Default for RateLimiterBuilder {
+    fn default() -> Self {
+        Self {
+            window_size_seconds: *WindowSizeSeconds::default(),
+            rate_group_size_ms: *RateGroupSizeMs::default(),
+            hard_limit_factor: *HardLimitFactor::default(),
+            suppression_factor_cache_ms: *SuppressionFactorCacheMs::default(),
+            stale_after_ms: 10 * 60 * 1000,
+            cleanup_interval_ms: 30 * 1000,
+        }
+    }
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+impl RateLimiter {
+    /// Create a builder for [`RateLimiter`] with sensible defaults.
+    pub fn builder() -> RateLimiterBuilder {
+        RateLimiterBuilder::default()
+    }
+}
+
+#[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
+impl RateLimiterBuilder {
+    fn new_with_connection_manager(connection_manager: ConnectionManager) -> Self {
+        Self {
+            window_size_seconds: *WindowSizeSeconds::default(),
+            rate_group_size_ms: *RateGroupSizeMs::default(),
+            hard_limit_factor: *HardLimitFactor::default(),
+            suppression_factor_cache_ms: *SuppressionFactorCacheMs::default(),
+            stale_after_ms: 10 * 60 * 1000,
+            cleanup_interval_ms: 30 * 1000,
+            connection_manager,
+            redis_prefix: None,
+            sync_interval_ms: *SyncIntervalMs::default(),
+        }
+    }
+}
+
+#[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
+impl RateLimiter {
+    /// Create a builder for [`RateLimiter`].
+    ///
+    /// The `connection_manager` is required because it has no default.
+    /// All other options default to sensible values.
+    pub fn builder(connection_manager: ConnectionManager) -> RateLimiterBuilder {
+        RateLimiterBuilder::new_with_connection_manager(connection_manager)
+    }
+}
+
+impl RateLimiterBuilder {
+    /// Set the sliding window duration in seconds. Default: [`WindowSizeSeconds::default()`].
+    pub fn window_size_seconds(mut self, v: u64) -> Self {
+        self.window_size_seconds = v;
+        self
+    }
+
+    /// Set the bucket coalescing interval in milliseconds. Default: [`RateGroupSizeMs::default()`].
+    pub fn rate_group_size_ms(mut self, v: u64) -> Self {
+        self.rate_group_size_ms = v;
+        self
+    }
+
+    /// Set the hard cutoff multiplier for the suppressed strategy. Default: [`HardLimitFactor::default()`].
+    pub fn hard_limit_factor(mut self, v: f64) -> Self {
+        self.hard_limit_factor = v;
+        self
+    }
+
+    /// Set the suppression factor cache duration in milliseconds. Default: [`SuppressionFactorCacheMs::default()`].
+    pub fn suppression_factor_cache_ms(mut self, v: u64) -> Self {
+        self.suppression_factor_cache_ms = v;
+        self
+    }
+
+    /// Set how long (ms) a key must be inactive before it is considered stale. Default: 600,000 (10 min).
+    pub fn stale_after_ms(mut self, v: u64) -> Self {
+        self.stale_after_ms = v;
+        self
+    }
+
+    /// Set how often (ms) the cleanup loop runs. Default: 30,000 (30 sec).
+    pub fn cleanup_interval_ms(mut self, v: u64) -> Self {
+        self.cleanup_interval_ms = v;
+        self
+    }
+
+    /// Set the Redis key prefix. Default: `None` (uses `"trypema"`).
+    #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
+    pub fn redis_prefix(mut self, v: RedisKey) -> Self {
+        self.redis_prefix = Some(v);
+        self
+    }
+
+    /// Set the hybrid provider sync interval in milliseconds. Default: [`SyncIntervalMs::default()`].
+    #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "redis-tokio", feature = "redis-smol"))))]
+    pub fn sync_interval_ms(mut self, v: u64) -> Self {
+        self.sync_interval_ms = v;
+        self
+    }
+
+    /// Build the [`RateLimiter`], wrapped in [`Arc`], with the cleanup loop already running.
+    ///
+    /// Returns `Err` if any option value fails validation.
+    pub fn build(self) -> Result<Arc<RateLimiter>, TrypemaError> {
+        let options = RateLimiterOptions {
+            local: LocalRateLimiterOptions {
+                window_size_seconds: WindowSizeSeconds::try_from(self.window_size_seconds)?,
+                rate_group_size_ms: RateGroupSizeMs::try_from(self.rate_group_size_ms)?,
+                hard_limit_factor: HardLimitFactor::try_from(self.hard_limit_factor)?,
+                suppression_factor_cache_ms: SuppressionFactorCacheMs::try_from(
+                    self.suppression_factor_cache_ms,
+                )?,
+            },
+            #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
+            redis: RedisRateLimiterOptions {
+                connection_manager: self.connection_manager,
+                prefix: self.redis_prefix,
+                window_size_seconds: WindowSizeSeconds::try_from(self.window_size_seconds)?,
+                rate_group_size_ms: RateGroupSizeMs::try_from(self.rate_group_size_ms)?,
+                hard_limit_factor: HardLimitFactor::try_from(self.hard_limit_factor)?,
+                suppression_factor_cache_ms: SuppressionFactorCacheMs::try_from(
+                    self.suppression_factor_cache_ms,
+                )?,
+                sync_interval_ms: SyncIntervalMs::try_from(self.sync_interval_ms)?,
+            },
+        };
+        let rl = Arc::new(RateLimiter::new(options));
+        rl.run_cleanup_loop_with_config(self.stale_after_ms, self.cleanup_interval_ms);
+        Ok(rl)
     }
 }

--- a/src/redis/absolute_redis_rate_limiter.rs
+++ b/src/redis/absolute_redis_rate_limiter.rs
@@ -267,6 +267,22 @@ impl AbsoluteRedisRateLimiter {
     /// - `Ok(Allowed)` — under limit, increment recorded
     /// - `Ok(Rejected { .. })` — over limit, increment **not** recorded
     /// - `Err(TrypemaError)` — Redis connectivity or script error
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// assert!(matches!(
+    ///     rl.redis().absolute().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub async fn inc(
         &self,
         key: &RedisKey,
@@ -306,13 +322,27 @@ impl AbsoluteRedisRateLimiter {
         }
     } // end method inc
 
-    /// Determine whether `key` is currently allowed.
+    /// Determine whether `key` is currently allowed (read-only).
     ///
     /// Returns [`RateLimitDecision::Allowed`] if the current sliding window total
     /// is below the window limit, otherwise returns [`RateLimitDecision::Rejected`]
-    /// with a best-effort `retry_after_ms`.
+    /// with a best-effort `retry_after_ms`. Does not record an increment.
     ///
-    /// This method performs lazy eviction of expired buckets for the key.
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// // Unknown key → always allowed
+    /// assert!(matches!(
+    ///     rl.redis().absolute().is_allowed(&key).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub async fn is_allowed(&self, key: &RedisKey) -> Result<RateLimitDecision, TrypemaError> {
         let mut connection_manager = self.connection_manager.clone();
 

--- a/src/redis/common.rs
+++ b/src/redis/common.rs
@@ -15,8 +15,9 @@ use crate::{TrypemaError, common::RateType};
 
 /// A validated newtype for Redis rate limiting keys.
 ///
-/// All Redis and hybrid provider operations require keys wrapped in this type. Validation
-/// is performed at construction time via `TryFrom<String>`.
+/// All Redis and hybrid provider operations require keys wrapped in this type. Validation happens
+/// at construction time, whether you use [`RedisKey::new`], [`TryFrom<String>`], or
+/// [`RedisKey::new_or_panic`].
 ///
 /// # Validation Rules
 ///
@@ -30,9 +31,9 @@ use crate::{TrypemaError, common::RateType};
 /// ```
 /// use trypema::redis::RedisKey;
 ///
-/// // Valid keys
-/// let key = RedisKey::try_from("user_123".to_string()).unwrap();
+/// let key = RedisKey::new("user_123".to_string()).unwrap();
 /// let key = RedisKey::try_from("api_v2_endpoint".to_string()).unwrap();
+/// let key = RedisKey::new_or_panic("team_alpha".to_string());
 ///
 /// // Invalid: contains ':'
 /// assert!(RedisKey::try_from("user:123".to_string()).is_err());

--- a/src/redis/common.rs
+++ b/src/redis/common.rs
@@ -1,8 +1,13 @@
 use std::{
     hash::Hash,
     ops::{Deref, DerefMut},
-    sync::Mutex,
+    sync::{LazyLock, Mutex},
 };
+
+use regex::Regex;
+
+static REDIS_KEY_STRIP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":").expect("REDIS_KEY_STRIP_RE is valid"));
 
 use dashmap::{DashMap, mapref::one::RefMut, try_result::TryResult};
 
@@ -49,6 +54,47 @@ impl RedisKey {
 
     pub(crate) fn from(value: String) -> Self {
         Self(value)
+    }
+
+    /// Fallible constructor. Equivalent to `TryFrom` but more ergonomic as a direct call.
+    pub fn new(value: String) -> Result<Self, crate::TrypemaError> {
+        Self::try_from(value)
+    }
+
+    /// Panicking constructor. The `_or_panic` suffix signals that this call can panic.
+    pub fn new_or_panic(value: String) -> Self {
+        Self::try_from(value).expect("invalid RedisKey")
+    }
+
+    /// Strip colons from `value`, then validate and return a [`RedisKey`].
+    ///
+    /// Colons are stripped because they are used internally as key separators
+    /// (e.g. `{prefix}:{key}:{rate_type}:{suffix}`). Returns `Err` if the sanitized
+    /// string is still invalid — for example, if `value` was entirely colons (empty
+    /// after stripping) or exceeds 255 bytes after stripping.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_sanitize("user:123".to_string()).unwrap();
+    /// assert_eq!(*key, "user123");
+    ///
+    /// // Entirely colons → empty after stripping → Err
+    /// assert!(RedisKey::try_sanitize(":".to_string()).is_err());
+    /// ```
+    pub fn try_sanitize(value: String) -> Result<Self, crate::TrypemaError> {
+        let sanitized = REDIS_KEY_STRIP_RE.replace_all(&value, "").into_owned();
+        Self::try_from(sanitized)
+    }
+
+    /// Strip colons from `value`, then return a [`RedisKey`].
+    ///
+    /// Panics if the sanitized string is still invalid (e.g. was entirely colons, or too long).
+    /// The `_or_panic` suffix signals that this call can panic.
+    pub fn sanitize_or_panic(value: String) -> Self {
+        Self::try_sanitize(value).expect("sanitized RedisKey value is still invalid")
     }
 }
 

--- a/src/redis/redis_rate_limiter_provider.rs
+++ b/src/redis/redis_rate_limiter_provider.rs
@@ -109,6 +109,40 @@ pub struct RedisRateLimiterOptions {
     pub sync_interval_ms: SyncIntervalMs,
 }
 
+impl RedisRateLimiterOptions {
+    /// Create a new [`RedisRateLimiterOptions`] with the given `connection_manager`.
+    ///
+    /// All other fields default to their type's [`Default`] value:
+    /// - `prefix`: `None` (uses `"trypema"`)
+    /// - `window_size_seconds`: [`WindowSizeSeconds::default()`]
+    /// - `rate_group_size_ms`: [`RateGroupSizeMs::default()`]
+    /// - `hard_limit_factor`: [`HardLimitFactor::default()`]
+    /// - `suppression_factor_cache_ms`: [`SuppressionFactorCacheMs::default()`]
+    /// - `sync_interval_ms`: [`SyncIntervalMs::default()`]
+    ///
+    /// Override specific fields with struct update syntax:
+    /// ```no_run
+    /// # use trypema::redis::RedisRateLimiterOptions;
+    /// # use trypema::WindowSizeSeconds;
+    /// # let connection_manager: redis::aio::ConnectionManager = todo!();
+    /// let options = RedisRateLimiterOptions {
+    ///     window_size_seconds: WindowSizeSeconds::new_or_panic(60),
+    ///     ..RedisRateLimiterOptions::new(connection_manager)
+    /// };
+    /// ```
+    pub fn new(connection_manager: ConnectionManager) -> Self {
+        Self {
+            connection_manager,
+            prefix: None,
+            window_size_seconds: WindowSizeSeconds::default(),
+            rate_group_size_ms: RateGroupSizeMs::default(),
+            hard_limit_factor: HardLimitFactor::default(),
+            suppression_factor_cache_ms: SuppressionFactorCacheMs::default(),
+            sync_interval_ms: SyncIntervalMs::default(),
+        }
+    }
+}
+
 /// Provider for Redis-backed distributed rate limiting.
 ///
 /// Enables rate limiting across multiple processes or servers using Redis as a

--- a/src/redis/redis_rate_limiter_provider.rs
+++ b/src/redis/redis_rate_limiter_provider.rs
@@ -8,34 +8,34 @@ use crate::{
 
 /// Configuration for Redis-backed rate limiters.
 ///
-/// Configures connection, key prefix, and rate limiting parameters for the Redis provider.
+/// Shared configuration for [`RedisRateLimiterProvider`] and
+/// [`crate::hybrid::HybridRateLimiterProvider`].
+///
+/// The same settings define the Redis connection, key prefix, windowing behavior, and hybrid
+/// sync interval.
 ///
 /// # Requirements
 ///
-/// - **Redis version:** >= 6.2.0
+/// - **Redis version:** >= 7.2.0
 /// - **Runtime:** Tokio or Smol (via `redis-tokio` or `redis-smol` features)
 ///
 /// # Examples
 ///
-/// ```rust,no_run
-/// # async fn example() -> Result<(), trypema::TrypemaError> {
-/// use trypema::{HardLimitFactor, RateGroupSizeMs, WindowSizeSeconds};
-/// use trypema::SuppressionFactorCacheMs;
-/// use trypema::hybrid::SyncIntervalMs;
-/// use trypema::redis::{RedisKey, RedisRateLimiterOptions};
+/// ```
+/// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+/// use trypema::redis::RedisRateLimiterOptions;
 ///
-/// let sync_interval_ms = SyncIntervalMs::default();
-/// let options = RedisRateLimiterOptions {
-///     connection_manager: todo!("create redis::aio::ConnectionManager"),
-///     prefix: Some(RedisKey::try_from("myapp".to_string())?),
-///     window_size_seconds: WindowSizeSeconds::try_from(60)?,
-///     rate_group_size_ms: RateGroupSizeMs::try_from(10)?,
-///     hard_limit_factor: HardLimitFactor::try_from(1.5)?,
-///     suppression_factor_cache_ms: SuppressionFactorCacheMs::default(),
-///     sync_interval_ms,
-/// };
-/// let _ = options;
-/// # Ok(()) }
+/// let url = std::env::var("REDIS_URL")
+///     .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+/// let conn = redis::Client::open(url)
+///     .unwrap()
+///     .get_connection_manager()
+///     .await
+///     .unwrap();
+///
+/// let _options = RedisRateLimiterOptions::new(conn);
+/// let _ = rl;
+/// # });
 /// ```
 #[derive(Clone, Debug)]
 pub struct RedisRateLimiterOptions {
@@ -43,14 +43,6 @@ pub struct RedisRateLimiterOptions {
     ///
     /// Use `ConnectionManager` for automatic connection pooling and reconnection.
     ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// # async fn example() -> Result<(), trypema::TrypemaError> {
-    /// let _connection_manager: redis::aio::ConnectionManager =
-    ///     todo!("create redis::aio::ConnectionManager");
-    /// # Ok(()) }
-    /// ```
     pub connection_manager: ConnectionManager,
 
     /// Optional prefix for all Redis keys.
@@ -67,36 +59,39 @@ pub struct RedisRateLimiterOptions {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```
     /// use trypema::redis::RedisKey;
     ///
     /// // With prefix: myapp:user_123:absolute:h
-    /// let _prefix = Some(RedisKey::try_from("myapp".to_string())?);
+    /// let _prefix = Some(RedisKey::try_from("myapp".to_string()).unwrap());
     ///
     /// // Default prefix: trypema:user_123:absolute:h
     /// let _prefix: Option<RedisKey> = None;
-    /// # Ok::<(), trypema::TrypemaError>(())
     /// ```
     pub prefix: Option<RedisKey>,
 
     /// Sliding window duration for admission decisions.
     ///
-    /// Same semantics as local provider. See [`WindowSizeSeconds`] for details.
+    /// Same semantics as [`crate::local::LocalRateLimiterOptions::window_size_seconds`]. See
+    /// [`WindowSizeSeconds`] for details.
     pub window_size_seconds: WindowSizeSeconds,
 
     /// Bucket coalescing interval in milliseconds.
     ///
-    /// Same semantics as local provider. See [`RateGroupSizeMs`] for details.
+    /// Same semantics as [`crate::local::LocalRateLimiterOptions::rate_group_size_ms`]. See
+    /// [`RateGroupSizeMs`] for details.
     pub rate_group_size_ms: RateGroupSizeMs,
 
     /// Hard cutoff multiplier for the suppressed strategy.
     ///
-    /// Same semantics as local provider. See [`HardLimitFactor`] for details.
+    /// Same semantics as [`crate::local::LocalRateLimiterOptions::hard_limit_factor`]. See
+    /// [`HardLimitFactor`] for details.
     pub hard_limit_factor: HardLimitFactor,
 
     /// Cache duration (milliseconds) for suppression factor recomputation.
     ///
-    /// Same semantics as local provider.
+    /// Same semantics as
+    /// [`crate::local::LocalRateLimiterOptions::suppression_factor_cache_ms`].
     pub suppression_factor_cache_ms: SuppressionFactorCacheMs,
 
     /// Sync interval (milliseconds) for the hybrid provider's background flush.
@@ -121,14 +116,26 @@ impl RedisRateLimiterOptions {
     /// - `sync_interval_ms`: [`SyncIntervalMs::default()`]
     ///
     /// Override specific fields with struct update syntax:
-    /// ```no_run
-    /// # use trypema::redis::RedisRateLimiterOptions;
-    /// # use trypema::WindowSizeSeconds;
-    /// # let connection_manager: redis::aio::ConnectionManager = todo!();
-    /// let options = RedisRateLimiterOptions {
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::WindowSizeSeconds;
+    /// use trypema::redis::RedisRateLimiterOptions;
+    ///
+    /// let url = std::env::var("REDIS_URL")
+    ///     .unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string());
+    /// let conn = redis::Client::open(url)
+    ///     .unwrap()
+    ///     .get_connection_manager()
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let _options = RedisRateLimiterOptions {
     ///     window_size_seconds: WindowSizeSeconds::new_or_panic(60),
-    ///     ..RedisRateLimiterOptions::new(connection_manager)
+    ///     ..RedisRateLimiterOptions::new(conn)
     /// };
+    /// let _ = rl;
+    /// # });
     /// ```
     pub fn new(connection_manager: ConnectionManager) -> Self {
         Self {
@@ -146,11 +153,12 @@ impl RedisRateLimiterOptions {
 /// Provider for Redis-backed distributed rate limiting.
 ///
 /// Enables rate limiting across multiple processes or servers using Redis as a
-/// shared backend. All operations are implemented as atomic Lua scripts.
+/// shared backend. All operations are implemented as atomic Lua scripts, so each individual Redis
+/// call is atomic while overall admission remains best-effort under concurrency.
 ///
 /// # Requirements
 ///
-/// - **Redis:** >= 6.2.0
+/// - **Redis:** >= 7.2.0
 /// - **Runtime:** Tokio or Smol
 ///
 /// # Strategies
@@ -168,51 +176,19 @@ impl RedisRateLimiterOptions {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
-/// # async fn example() -> Result<(), trypema::TrypemaError> {
-/// use trypema::{
-///     HardLimitFactor, RateGroupSizeMs, RateLimit, RateLimitDecision, RateLimiter,
-///     RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds,
-/// };
-/// use trypema::hybrid::SyncIntervalMs;
-/// use trypema::local::LocalRateLimiterOptions;
-/// use trypema::redis::{RedisKey, RedisRateLimiterOptions};
+/// ```
+/// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+/// use trypema::{RateLimit, RateLimitDecision};
+/// use trypema::redis::RedisKey;
 ///
-/// let window_size_seconds = WindowSizeSeconds::try_from(60)?;
-/// let rate_group_size_ms = RateGroupSizeMs::try_from(10)?;
-/// let hard_limit_factor = HardLimitFactor::default();
-/// let suppression_factor_cache_ms = SuppressionFactorCacheMs::default();
-/// let sync_interval_ms = SyncIntervalMs::default();
+/// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+/// let rate = RateLimit::try_from(10.0).unwrap();
 ///
-/// let rl = RateLimiter::new(RateLimiterOptions {
-///     local: LocalRateLimiterOptions {
-///         window_size_seconds,
-///         rate_group_size_ms,
-///         hard_limit_factor,
-///         suppression_factor_cache_ms,
-///     },
-///     redis: RedisRateLimiterOptions {
-///         connection_manager: todo!("create redis::aio::ConnectionManager"),
-///         prefix: None,
-///         window_size_seconds,
-///         rate_group_size_ms,
-///         hard_limit_factor,
-///         suppression_factor_cache_ms,
-///         sync_interval_ms,
-///     },
-/// });
-///
-/// let key = RedisKey::try_from("user_123".to_string())?;
-/// let rate = RateLimit::try_from(10.0)?;
-///
-/// match rl.redis().absolute().inc(&key, &rate, 1).await? {
-///     RateLimitDecision::Allowed => {}
-///     RateLimitDecision::Rejected { retry_after_ms, .. } => {
-///         let _ = retry_after_ms;
-///     }
-///     _ => unreachable!(),
-/// }
-/// # Ok(()) }
+/// assert!(matches!(
+///     rl.redis().absolute().inc(&key, &rate, 1).await.unwrap(),
+///     RateLimitDecision::Allowed
+/// ));
+/// # });
 /// ```
 #[derive(Clone, Debug)]
 pub struct RedisRateLimiterProvider {
@@ -239,10 +215,18 @@ impl RedisRateLimiterProvider {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// # async fn example(rl: &trypema::RateLimiter, key: &trypema::redis::RedisKey, rate: &trypema::RateLimit) -> Result<(), trypema::TrypemaError> {
-    /// let _decision = rl.redis().absolute().inc(key, rate, 1).await?;
-    /// # Ok(()) }
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// assert!(matches!(
+    ///     rl.redis().absolute().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
     /// ```
     pub fn absolute(&self) -> &AbsoluteRedisRateLimiter {
         &self.absolute
@@ -256,6 +240,29 @@ impl RedisRateLimiterProvider {
     /// distributed probabilistic suppression via atomic Lua scripts.
     ///
     /// See [`SuppressedRedisRateLimiter`] for full documentation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    ///
+    /// match rl.redis().suppressed().inc(&key, &rate, 1).await.unwrap() {
+    ///     RateLimitDecision::Allowed => {}
+    ///     RateLimitDecision::Suppressed {
+    ///         is_allowed,
+    ///         suppression_factor,
+    ///     } => {
+    ///         let _ = (is_allowed, suppression_factor);
+    ///     }
+    ///     RateLimitDecision::Rejected { .. } => unreachable!(),
+    /// }
+    /// # });
+    /// ```
     pub fn suppressed(&self) -> &SuppressedRedisRateLimiter {
         &self.suppressed
     }

--- a/src/redis/suppressed_redis_rate_limiter.rs
+++ b/src/redis/suppressed_redis_rate_limiter.rs
@@ -333,6 +333,23 @@ impl SuppressedRedisRateLimiter {
     ///
     /// The total observed counter is **always** incremented, regardless of the decision.
     /// If `is_allowed` is `false`, the declined counter is also incremented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::{RateLimit, RateLimitDecision};
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// let rate = RateLimit::try_from(10.0).unwrap();
+    /// // Under limit → Allowed
+    /// assert!(matches!(
+    ///     rl.redis().suppressed().inc(&key, &rate, 1).await.unwrap(),
+    ///     RateLimitDecision::Allowed
+    /// ));
+    /// # });
+    /// ```
     pub async fn inc(
         &self,
         key: &RedisKey,
@@ -392,6 +409,18 @@ impl SuppressedRedisRateLimiter {
     /// directly. Otherwise, this recomputes the factor via the same algorithm used in `inc()`
     /// and writes it back to Redis with a `suppression_factor_cache_ms` TTL. If the cached
     /// value is outside `[0.0, 1.0]`, it is treated as stale and recomputed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # trypema::__doctest_helpers::with_redis_rate_limiter(|rl| async move {
+    /// use trypema::redis::RedisKey;
+    ///
+    /// let key = RedisKey::try_from(trypema::__doctest_helpers::unique_key()).unwrap();
+    /// // No state yet → 0.0 (no suppression)
+    /// assert_eq!(rl.redis().suppressed().get_suppression_factor(&key).await.unwrap(), 0.0);
+    /// # });
+    /// ```
     pub async fn get_suppression_factor(&self, key: &RedisKey) -> Result<f64, TrypemaError> {
         let mut connection_manager = self.connection_manager.clone();
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod test_absolute_hybrid_rate_limiter;
 mod test_absolute_local_rate_limiter;
 #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]
 mod test_absolute_redis_rate_limiter;
+mod test_builder;
 mod test_cleanup_loop;
 mod test_common_validation;
 #[cfg(any(feature = "redis-tokio", feature = "redis-smol"))]

--- a/src/tests/test_absolute_local_rate_limiter.rs
+++ b/src/tests/test_absolute_local_rate_limiter.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::VecDeque,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{Arc, atomic::AtomicU64},
     thread,
     time::{Duration, Instant},
 };

--- a/src/tests/test_builder.rs
+++ b/src/tests/test_builder.rs
@@ -1,0 +1,340 @@
+//! Tests for `RateLimiterBuilder`, `Default` impls, and `Drop` behaviour.
+
+use std::{sync::Arc, time::Duration};
+
+use crate::{
+    HardLimitFactor, LocalRateLimiterOptions, RateGroupSizeMs, RateLimit, RateLimiter,
+    RateLimiterOptions, SuppressionFactorCacheMs, WindowSizeSeconds,
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Defaults
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn window_size_seconds_default_is_10() {
+    assert_eq!(*WindowSizeSeconds::default(), 10);
+}
+
+#[test]
+fn local_rate_limiter_options_default_has_expected_field_defaults() {
+    let opts = LocalRateLimiterOptions::default();
+    assert_eq!(*opts.window_size_seconds, *WindowSizeSeconds::default());
+    assert_eq!(*opts.rate_group_size_ms, *RateGroupSizeMs::default());
+    assert_eq!(*opts.hard_limit_factor, *HardLimitFactor::default());
+    assert_eq!(
+        *opts.suppression_factor_cache_ms,
+        *SuppressionFactorCacheMs::default()
+    );
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn rate_limiter_options_default_composes_local_defaults() {
+    let opts = RateLimiterOptions::default();
+    assert_eq!(
+        *opts.local.window_size_seconds,
+        *WindowSizeSeconds::default()
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Builder: successful construction
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_default_build_succeeds() {
+    let rl = RateLimiter::builder().build();
+    assert!(rl.is_ok(), "default builder should succeed");
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_returns_arc() {
+    let rl: Arc<RateLimiter> = RateLimiter::builder().build().unwrap();
+    // Verify we can clone the Arc and both halves refer to the same limiter.
+    let rl2 = Arc::clone(&rl);
+    assert!(Arc::ptr_eq(&rl, &rl2));
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_produced_limiter_is_functional() {
+    let rl = RateLimiter::builder()
+        .window_size_seconds(60)
+        .build()
+        .unwrap();
+
+    let rate = RateLimit::new_or_panic(5.0);
+    // First inc on an unknown key is always allowed.
+    let decision = rl.local().absolute().inc("user_1", &rate, 1);
+    assert!(
+        matches!(decision, crate::RateLimitDecision::Allowed),
+        "first inc should be allowed"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Builder: setters are applied
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_window_size_setter_is_applied() {
+    // Window of 1 second: capacity = 1 req/s × 1 s = 1 request.
+    let rl = RateLimiter::builder()
+        .window_size_seconds(1)
+        .build()
+        .unwrap();
+
+    let rate = RateLimit::new_or_panic(1.0);
+    assert!(matches!(
+        rl.local().absolute().inc("k", &rate, 1),
+        crate::RateLimitDecision::Allowed
+    ));
+    assert!(matches!(
+        rl.local().absolute().inc("k", &rate, 1),
+        crate::RateLimitDecision::Rejected { .. }
+    ));
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_rate_group_size_ms_setter_is_applied() {
+    // Just verify the builder accepts and applies the value without error.
+    let rl = RateLimiter::builder()
+        .rate_group_size_ms(50)
+        .build()
+        .unwrap();
+    let rate = RateLimit::new_or_panic(10.0);
+    assert!(matches!(
+        rl.local().absolute().inc("k", &rate, 1),
+        crate::RateLimitDecision::Allowed
+    ));
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_hard_limit_factor_setter_is_applied() {
+    // Just verify a valid value is accepted and the limiter is usable.
+    // hard_limit_factor only affects the suppressed strategy once the rate
+    // exceeds the limit; we can't easily hit that threshold here.
+    let rl = RateLimiter::builder()
+        .hard_limit_factor(1.5)
+        .build()
+        .unwrap();
+    let rate = RateLimit::new_or_panic(10.0);
+    // First inc on a fresh key is always allowed regardless of strategy.
+    let decision = rl.local().absolute().inc("k", &rate, 1);
+    assert!(
+        matches!(decision, crate::RateLimitDecision::Allowed),
+        "limiter built with hard_limit_factor(1.5) should be functional"
+    );
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_suppression_factor_cache_ms_setter_is_applied() {
+    let rl = RateLimiter::builder()
+        .suppression_factor_cache_ms(50)
+        .build()
+        .unwrap();
+    let rate = RateLimit::new_or_panic(10.0);
+    assert!(matches!(
+        rl.local().absolute().inc("k", &rate, 1),
+        crate::RateLimitDecision::Allowed
+    ));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Builder: validation errors propagate through build()
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_invalid_window_size_returns_err() {
+    let result = RateLimiter::builder().window_size_seconds(0).build();
+    assert!(result.is_err(), "window_size_seconds(0) should fail");
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_invalid_rate_group_size_returns_err() {
+    let result = RateLimiter::builder().rate_group_size_ms(0).build();
+    assert!(result.is_err(), "rate_group_size_ms(0) should fail");
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_invalid_hard_limit_factor_returns_err() {
+    let result = RateLimiter::builder().hard_limit_factor(0.5).build();
+    assert!(result.is_err(), "hard_limit_factor(0.5) should fail");
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_invalid_suppression_factor_cache_ms_returns_err() {
+    let result = RateLimiter::builder()
+        .suppression_factor_cache_ms(0)
+        .build();
+    assert!(
+        result.is_err(),
+        "suppression_factor_cache_ms(0) should fail"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Builder: cleanup loop starts automatically
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_cleanup_loop_runs_with_custom_timing() {
+    let rl = RateLimiter::builder()
+        .window_size_seconds(60)
+        .stale_after_ms(100)
+        .cleanup_interval_ms(50)
+        .build()
+        .unwrap();
+
+    let rate = RateLimit::new_or_panic(100.0);
+    rl.local().absolute().inc("k1", &rate, 1);
+    rl.local().absolute().inc("k2", &rate, 1);
+    assert_eq!(rl.local().absolute().series().len(), 2);
+
+    // Wait for keys to become stale and one cleanup tick to run.
+    std::thread::sleep(Duration::from_millis(250));
+    assert_eq!(
+        rl.local().absolute().series().len(),
+        0,
+        "stale keys should have been cleaned up"
+    );
+}
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_cleanup_loop_is_idempotent_after_build() {
+    // Calling run_cleanup_loop_with_config after build() must be a no-op
+    // (loop is already running; second call is ignored).
+    let rl = RateLimiter::builder()
+        .stale_after_ms(5_000) // long threshold — keys should NOT be removed
+        .cleanup_interval_ms(50)
+        .build()
+        .unwrap();
+
+    let rate = RateLimit::new_or_panic(100.0);
+    rl.local().absolute().inc("k1", &rate, 1);
+    assert_eq!(rl.local().absolute().series().len(), 1);
+
+    // Second call: aggressive config. Must be ignored since loop is already running.
+    rl.run_cleanup_loop_with_config(10, 50);
+
+    std::thread::sleep(Duration::from_millis(150));
+    assert_eq!(
+        rl.local().absolute().series().len(),
+        1,
+        "idempotent: second run_cleanup_loop_with_config must not override the first"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Drop: cleanup loop stops when Arc is dropped
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn drop_stops_cleanup_loop() {
+    let rate = RateLimit::new_or_panic(100.0);
+
+    let rl = RateLimiter::builder()
+        .stale_after_ms(100)
+        .cleanup_interval_ms(50)
+        .build()
+        .unwrap();
+
+    // Seed one key and wait for the loop to clean it up to confirm it's running.
+    rl.local().absolute().inc("seed", &rate, 1);
+    std::thread::sleep(Duration::from_millis(250));
+    assert_eq!(
+        rl.local().absolute().series().len(),
+        0,
+        "loop should have cleaned up the seed key"
+    );
+
+    // Drop the only Arc — this should stop the loop via Drop.
+    drop(rl);
+
+    // Build a *new* rate limiter using the raw API so we can manually check
+    // the cleanup doesn't continue (we can't inspect the old one after drop).
+    let rl2 = Arc::new(RateLimiter::new(RateLimiterOptions {
+        local: LocalRateLimiterOptions {
+            window_size_seconds: WindowSizeSeconds::new_or_panic(60),
+            ..LocalRateLimiterOptions::default()
+        },
+    }));
+
+    // Start a loop, add a key, stop the loop explicitly, confirm key stays.
+    rl2.local().absolute().inc("k", &rate, 1);
+    rl2.run_cleanup_loop_with_config(100, 50);
+    std::thread::sleep(Duration::from_millis(20));
+    rl2.stop_cleanup_loop();
+    std::thread::sleep(Duration::from_millis(250));
+    assert_eq!(
+        rl2.local().absolute().series().len(),
+        1,
+        "after stop, stale key should remain"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// stop_cleanup_loop: callable via &self (no Arc receiver required)
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn stop_cleanup_loop_callable_on_deref_of_arc() {
+    let rl: Arc<RateLimiter> = RateLimiter::builder()
+        .stale_after_ms(100)
+        .cleanup_interval_ms(50)
+        .build()
+        .unwrap();
+
+    let rate = RateLimit::new_or_panic(100.0);
+    rl.local().absolute().inc("k", &rate, 1);
+
+    // This call must compile: Arc<RateLimiter> auto-derefs to RateLimiter,
+    // and stop_cleanup_loop now takes &self rather than self: &Arc<Self>.
+    rl.stop_cleanup_loop();
+
+    std::thread::sleep(Duration::from_millis(250));
+    assert_eq!(
+        rl.local().absolute().series().len(),
+        1,
+        "loop was stopped so stale key should not be removed"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Builder: chaining all setters in one expression
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(any(feature = "redis-tokio", feature = "redis-smol")))]
+#[test]
+fn builder_full_chain_compiles_and_works() {
+    let rl = RateLimiter::builder()
+        .window_size_seconds(30)
+        .rate_group_size_ms(10)
+        .hard_limit_factor(1.5)
+        .suppression_factor_cache_ms(50)
+        .stale_after_ms(300_000)
+        .cleanup_interval_ms(60_000)
+        .build()
+        .unwrap();
+
+    let rate = RateLimit::new_or_panic(10.0);
+    assert!(matches!(
+        rl.local().absolute().inc("k", &rate, 1),
+        crate::RateLimitDecision::Allowed
+    ));
+}

--- a/src/tests/test_cleanup_loop.rs
+++ b/src/tests/test_cleanup_loop.rs
@@ -394,7 +394,10 @@ fn test_hybrid_absolute_cleanup_loop_removes_stale_redis_keys() {
 
         for entity_key in kg.get_all_entity_keys(&k) {
             let exists: bool = conn.exists(&entity_key).await.unwrap();
-            assert!(!exists, "key {entity_key} must be absent after cleanup loop");
+            assert!(
+                !exists,
+                "key {entity_key} must be absent after cleanup loop"
+            );
         }
 
         let score: Option<f64> = conn.zscore(&active_entities_key, k.as_str()).await.unwrap();
@@ -576,7 +579,10 @@ fn test_hybrid_suppressed_cleanup_loop_removes_stale_redis_keys() {
 
         for entity_key in kg.get_all_entity_keys(&k) {
             let exists: bool = conn.exists(&entity_key).await.unwrap();
-            assert!(!exists, "key {entity_key} must be absent after cleanup loop");
+            assert!(
+                !exists,
+                "key {entity_key} must be absent after cleanup loop"
+            );
         }
 
         let score: Option<f64> = conn.zscore(&active_entities_key, k.as_str()).await.unwrap();

--- a/src/tests/test_redis_state_absolute_hybrid_rate_limiter.rs
+++ b/src/tests/test_redis_state_absolute_hybrid_rate_limiter.rs
@@ -21,8 +21,8 @@ use std::{collections::HashMap, time::Duration};
 
 use redis::AsyncCommands;
 
+use super::common::{key, key_gen, redis_url, unique_prefix, wait_for_hybrid_sync};
 use super::runtime;
-use super::common::{redis_url, unique_prefix, key, key_gen, wait_for_hybrid_sync};
 
 use crate::common::{RateType, SuppressionFactorCacheMs};
 use crate::hybrid::SyncIntervalMs;
@@ -74,7 +74,7 @@ fn redis_key(prefix: &RedisKey, user_key: &RedisKey, suffix: &str) -> String {
         "a" => kg.get_active_keys(user_key),
         "w" => kg.get_window_limit_key(user_key),
         "t" => kg.get_total_count_key(user_key),
-        _   => panic!("unknown suffix for hybrid_absolute rate type: {suffix}"),
+        _ => panic!("unknown suffix for hybrid_absolute rate type: {suffix}"),
     }
 }
 
@@ -93,12 +93,24 @@ fn redis_state_hybrid_absolute_no_redis_keys_before_overflow() {
         let window_size_seconds = 1_u64;
         let sync_interval_ms = 2000_u64; // very slow tick so no background flush occurs
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
         // capacity = 1 * 5 = 5; fill all 5 slots locally.
         for _ in 0..5 {
-            let d = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let d = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
             assert!(matches!(d, RateLimitDecision::Allowed), "d: {d:?}");
         }
 
@@ -130,19 +142,36 @@ fn redis_state_hybrid_absolute_commit_writes_total_count_after_overflow() {
         let window_size_seconds = 1_u64;
         let sync_interval_ms = 25_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
         let cap = (window_size_seconds as f64 * *rate_limit) as u64; // 5
 
         // Fill the local budget.
         for _ in 0..cap {
-            let d = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let d = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
             assert!(matches!(d, RateLimitDecision::Allowed), "d: {d:?}");
         }
 
         // Trigger overflow — this queues the commit.
-        let d_overflow = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let d_overflow = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         assert!(
             matches!(d_overflow, RateLimitDecision::Rejected { .. }),
             "d_overflow: {d_overflow:?}"
@@ -169,7 +198,10 @@ fn redis_state_hybrid_absolute_commit_writes_total_count_after_overflow() {
 
         // The hash must have at least one bucket.
         let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
-        assert!(!hash.is_empty(), "hash must have at least one bucket after commit");
+        assert!(
+            !hash.is_empty(),
+            "hash must have at least one bucket after commit"
+        );
 
         // The active sorted set must have at least one member.
         let active_count: u64 = conn.zcard(redis_key(&prefix, &k, "a")).await.unwrap();
@@ -190,17 +222,34 @@ fn redis_state_hybrid_absolute_window_limit_key_is_set_after_commit() {
         let window_size_seconds = 2_u64;
         let sync_interval_ms = 25_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(3f64).unwrap();
         // capacity = 2 * 3 = 6
         let expected_window_limit = 6_u64;
 
         for _ in 0..expected_window_limit {
-            let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
         // Overflow to trigger commit.
-        let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         let mut conn = redis::Client::open(url.as_str())
@@ -228,16 +277,33 @@ fn redis_state_hybrid_absolute_committed_state_is_visible_to_another_instance() 
         let window_size_seconds = 1_u64;
         let sync_interval_ms = 25_u64;
 
-        let rl_a = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl_a = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
         let cap = (window_size_seconds as f64 * *rate_limit) as u64;
 
         // A fills and overflows.
         for _ in 0..cap {
-            let _ = rl_a.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl_a
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl_a.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl_a
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         let mut conn = redis::Client::open(url.as_str())
@@ -264,15 +330,32 @@ fn redis_state_hybrid_absolute_hash_sum_matches_total_count_after_commit() {
         let window_size_seconds = 1_u64;
         let sync_interval_ms = 25_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
         let cap = (window_size_seconds as f64 * *rate_limit) as u64;
 
         for _ in 0..cap {
-            let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         let mut conn = redis::Client::open(url.as_str())
@@ -303,24 +386,49 @@ fn redis_state_hybrid_absolute_evicts_expired_buckets_on_next_commit() {
         let window_size_seconds = 1_u64;
         let sync_interval_ms = 25_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
         let cap = (window_size_seconds as f64 * *rate_limit) as u64;
 
         // First burst: fill and overflow to commit.
         for _ in 0..cap {
-            let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         // Wait for the window to expire.
         runtime::async_sleep(Duration::from_millis(window_size_seconds * 1000 + 100)).await;
 
         // Second burst: this read_state call in the hybrid limiter triggers Redis eviction.
-        let d = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
-        assert!(matches!(d, RateLimitDecision::Allowed), "d after expiry: {d:?}");
+        let d = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
+        assert!(
+            matches!(d, RateLimitDecision::Allowed),
+            "d after expiry: {d:?}"
+        );
         // Let the new commit flush if needed.
         wait_for_hybrid_sync(sync_interval_ms).await;
 
@@ -350,8 +458,22 @@ fn redis_state_hybrid_absolute_different_prefixes_are_isolated() {
         let window_size_seconds = 1_u64;
         let sync_interval_ms = 25_u64;
 
-        let rl_a = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix_a.clone()).await;
-        let rl_b = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix_b.clone()).await;
+        let rl_a = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix_a.clone(),
+        )
+        .await;
+        let rl_b = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix_b.clone(),
+        )
+        .await;
 
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
@@ -359,9 +481,19 @@ fn redis_state_hybrid_absolute_different_prefixes_are_isolated() {
 
         // Overflow A to trigger commit.
         for _ in 0..cap {
-            let _ = rl_a.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl_a
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl_a.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl_a
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         let mut conn = redis::Client::open(url.as_str())
@@ -378,7 +510,12 @@ fn redis_state_hybrid_absolute_different_prefixes_are_isolated() {
         );
 
         // Sanity: B can still operate independently.
-        let d_b = rl_b.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let d_b = rl_b
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         assert!(matches!(d_b, RateLimitDecision::Allowed), "d_b: {d_b:?}");
     });
 }
@@ -396,26 +533,60 @@ fn redis_state_hybrid_absolute_active_sorted_set_scores_are_ordered() {
         let rate_group_size_ms = 100_u64;
         let sync_interval_ms = 50_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, rate_group_size_ms, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            rate_group_size_ms,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(10f64).unwrap();
 
         // Trigger two separate overflow+commit cycles with a gap between them.
         for _ in 0..10 {
-            let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         // A brief pause ensures the next commit lands in a later ms bucket.
         runtime::async_sleep(Duration::from_millis(200)).await;
 
         // Reset local state so we can accumulate more.
-        let rl2 = build_limiter(&url, window_size_seconds, rate_group_size_ms, sync_interval_ms, prefix.clone()).await;
+        let rl2 = build_limiter(
+            &url,
+            window_size_seconds,
+            rate_group_size_ms,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         for _ in 0..10 {
-            let _ = rl2.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl2
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl2.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl2
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         let mut conn = redis::Client::open(url.as_str())
@@ -460,19 +631,37 @@ fn redis_state_hybrid_absolute_cleanup_removes_all_redis_keys_for_stale_entity()
         let sync_interval_ms = 25_u64;
         let stale_after_ms = 150_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
         let cap = (window_size_seconds as f64 * *rate_limit) as u64;
 
         // Overflow to trigger a Redis commit.
         for _ in 0..cap {
-            let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
-        let active_entities_key = key_gen(&prefix, RateType::HybridAbsolute).get_active_entities_key();
+        let active_entities_key =
+            key_gen(&prefix, RateType::HybridAbsolute).get_active_entities_key();
 
         let mut conn = redis::Client::open(url.as_str())
             .unwrap()
@@ -496,12 +685,19 @@ fn redis_state_hybrid_absolute_cleanup_removes_all_redis_keys_for_stale_entity()
             }
         }
         let score: Option<f64> = conn.zscore(&active_entities_key, k.as_str()).await.unwrap();
-        assert!(score.is_some(), "entity must be in active_entities before cleanup");
+        assert!(
+            score.is_some(),
+            "entity must be in active_entities before cleanup"
+        );
 
         // Wait until the entity is stale.
         runtime::async_sleep(Duration::from_millis(stale_after_ms + 50)).await;
 
-        rl.hybrid().absolute().cleanup(stale_after_ms).await.unwrap();
+        rl.hybrid()
+            .absolute()
+            .cleanup(stale_after_ms)
+            .await
+            .unwrap();
 
         // All per-entity keys must be deleted.
         for entity_key in kg.get_all_entity_keys(&k) {
@@ -511,7 +707,10 @@ fn redis_state_hybrid_absolute_cleanup_removes_all_redis_keys_for_stale_entity()
 
         // Entity must be removed from active_entities.
         let score_after: Option<f64> = conn.zscore(&active_entities_key, k.as_str()).await.unwrap();
-        assert!(score_after.is_none(), "entity must be removed from active_entities after cleanup");
+        assert!(
+            score_after.is_none(),
+            "entity must be removed from active_entities after cleanup"
+        );
     });
 }
 
@@ -526,22 +725,44 @@ fn redis_state_hybrid_absolute_cleanup_does_not_remove_active_entity() {
         let sync_interval_ms = 25_u64;
         let stale_after_ms = 5_000_u64; // very long — entity will not be stale yet
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
         let cap = (window_size_seconds as f64 * *rate_limit) as u64;
 
         // Overflow and sync — entity is recent.
         for _ in 0..cap {
-            let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let _ = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         // Immediately cleanup with a long threshold — nothing should be removed.
-        rl.hybrid().absolute().cleanup(stale_after_ms).await.unwrap();
+        rl.hybrid()
+            .absolute()
+            .cleanup(stale_after_ms)
+            .await
+            .unwrap();
 
-        let active_entities_key = key_gen(&prefix, RateType::HybridAbsolute).get_active_entities_key();
+        let active_entities_key =
+            key_gen(&prefix, RateType::HybridAbsolute).get_active_entities_key();
 
         let mut conn = redis::Client::open(url.as_str())
             .unwrap()
@@ -550,9 +771,15 @@ fn redis_state_hybrid_absolute_cleanup_does_not_remove_active_entity() {
             .unwrap();
 
         let t_exists: bool = conn.exists(redis_key(&prefix, &k, "t")).await.unwrap();
-        assert!(t_exists, "total count key must still exist for active entity");
+        assert!(
+            t_exists,
+            "total count key must still exist for active entity"
+        );
         let score: Option<f64> = conn.zscore(&active_entities_key, k.as_str()).await.unwrap();
-        assert!(score.is_some(), "active entity must remain in active_entities after cleanup");
+        assert!(
+            score.is_some(),
+            "active entity must remain in active_entities after cleanup"
+        );
     });
 }
 
@@ -568,16 +795,33 @@ fn redis_state_hybrid_absolute_cleanup_allows_fresh_requests_after_cleanup() {
         let sync_interval_ms = 25_u64;
         let stale_after_ms = 150_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(2f64).unwrap();
         let cap = (window_size_seconds as f64 * *rate_limit) as u64; // 10
 
         // Fill capacity then overflow — entity ends up in Rejecting state.
         for _ in 0..cap {
-            let _ = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&k, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let rejected = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let rejected = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         assert!(
             matches!(rejected, RateLimitDecision::Rejected { .. }),
             "expected Rejected after overflow, got {rejected:?}"
@@ -586,7 +830,11 @@ fn redis_state_hybrid_absolute_cleanup_allows_fresh_requests_after_cleanup() {
 
         // Wait until entity is stale, then clean up.
         runtime::async_sleep(Duration::from_millis(stale_after_ms + 50)).await;
-        rl.hybrid().absolute().cleanup(stale_after_ms).await.unwrap();
+        rl.hybrid()
+            .absolute()
+            .cleanup(stale_after_ms)
+            .await
+            .unwrap();
 
         let mut conn = redis::Client::open(url.as_str())
             .unwrap()
@@ -598,7 +846,12 @@ fn redis_state_hybrid_absolute_cleanup_allows_fresh_requests_after_cleanup() {
         assert!(!t_exists, "total count key must be deleted after cleanup");
 
         // The next request must be allowed — stale in-memory Rejecting state must be cleared.
-        let decision = rl.hybrid().absolute().inc(&k, &rate_limit, 1).await.unwrap();
+        let decision = rl
+            .hybrid()
+            .absolute()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
         assert!(
             matches!(decision, RateLimitDecision::Allowed),
             "expected Allowed after cleanup but got {decision:?}"
@@ -618,7 +871,14 @@ fn redis_state_hybrid_absolute_cleanup_multiple_entities_mixed() {
         let sync_interval_ms = 25_u64;
         let stale_after_ms = 150_u64;
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let stale = key("stale_user");
         let active = key("active_user");
         let rate_limit = RateLimit::try_from(2f64).unwrap();
@@ -626,25 +886,57 @@ fn redis_state_hybrid_absolute_cleanup_multiple_entities_mixed() {
 
         // Overflow stale_user and sync.
         for _ in 0..cap {
-            let _ = rl.hybrid().absolute().inc(&stale, &rate_limit, 1).await.unwrap();
+            let _ = rl
+                .hybrid()
+                .absolute()
+                .inc(&stale, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl.hybrid().absolute().inc(&stale, &rate_limit, 1).await.unwrap();
+        let _ = rl
+            .hybrid()
+            .absolute()
+            .inc(&stale, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
         // Wait for stale_user to become stale.
         runtime::async_sleep(Duration::from_millis(stale_after_ms + 50)).await;
 
         // Now overflow active_user — its commit timestamp is recent.
-        let rl2 = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl2 = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         for _ in 0..cap {
-            let _ = rl2.hybrid().absolute().inc(&active, &rate_limit, 1).await.unwrap();
+            let _ = rl2
+                .hybrid()
+                .absolute()
+                .inc(&active, &rate_limit, 1)
+                .await
+                .unwrap();
         }
-        let _ = rl2.hybrid().absolute().inc(&active, &rate_limit, 1).await.unwrap();
+        let _ = rl2
+            .hybrid()
+            .absolute()
+            .inc(&active, &rate_limit, 1)
+            .await
+            .unwrap();
         wait_for_hybrid_sync(sync_interval_ms).await;
 
-        rl2.hybrid().absolute().cleanup(stale_after_ms).await.unwrap();
+        rl2.hybrid()
+            .absolute()
+            .cleanup(stale_after_ms)
+            .await
+            .unwrap();
 
-        let active_entities_key = key_gen(&prefix, RateType::HybridAbsolute).get_active_entities_key();
+        let active_entities_key =
+            key_gen(&prefix, RateType::HybridAbsolute).get_active_entities_key();
 
         let mut conn = redis::Client::open(url.as_str())
             .unwrap()
@@ -655,14 +947,26 @@ fn redis_state_hybrid_absolute_cleanup_multiple_entities_mixed() {
         // stale_user keys must be gone.
         let stale_t: bool = conn.exists(redis_key(&prefix, &stale, "t")).await.unwrap();
         assert!(!stale_t, "stale_user total count key must be deleted");
-        let stale_score: Option<f64> = conn.zscore(&active_entities_key, stale.as_str()).await.unwrap();
-        assert!(stale_score.is_none(), "stale_user must be removed from active_entities");
+        let stale_score: Option<f64> = conn
+            .zscore(&active_entities_key, stale.as_str())
+            .await
+            .unwrap();
+        assert!(
+            stale_score.is_none(),
+            "stale_user must be removed from active_entities"
+        );
 
         // active_user keys must still exist.
         let active_t: bool = conn.exists(redis_key(&prefix, &active, "t")).await.unwrap();
         assert!(active_t, "active_user total count key must still exist");
-        let active_score: Option<f64> = conn.zscore(&active_entities_key, active.as_str()).await.unwrap();
-        assert!(active_score.is_some(), "active_user must remain in active_entities");
+        let active_score: Option<f64> = conn
+            .zscore(&active_entities_key, active.as_str())
+            .await
+            .unwrap();
+        assert!(
+            active_score.is_some(),
+            "active_user must remain in active_entities"
+        );
     });
 }
 
@@ -678,7 +982,14 @@ fn redis_state_hybrid_absolute_redis_absolute_keys_do_not_contaminate_hybrid_key
         let window_size_seconds = 1_u64;
         let sync_interval_ms = 2000_u64; // slow tick
 
-        let rl = build_limiter(&url, window_size_seconds, 1000, sync_interval_ms, prefix.clone()).await;
+        let rl = build_limiter(
+            &url,
+            window_size_seconds,
+            1000,
+            sync_interval_ms,
+            prefix.clone(),
+        )
+        .await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(5f64).unwrap();
 

--- a/src/tests/test_redis_state_absolute_redis_rate_limiter.rs
+++ b/src/tests/test_redis_state_absolute_redis_rate_limiter.rs
@@ -19,8 +19,8 @@ use std::{collections::HashMap, thread, time::Duration};
 
 use redis::AsyncCommands;
 
+use super::common::{key, key_gen, redis_url, unique_prefix};
 use super::runtime;
-use super::common::{redis_url, unique_prefix, key, key_gen};
 
 use crate::common::{RateType, SuppressionFactorCacheMs};
 use crate::hybrid::SyncIntervalMs;
@@ -64,11 +64,11 @@ async fn build_limiter(
 fn redis_key(prefix: &RedisKey, user_key: &RedisKey, suffix: &str) -> String {
     let kg = key_gen(prefix, RateType::Absolute);
     match suffix {
-        "h"  => kg.get_hash_key(user_key),
-        "a"  => kg.get_active_keys(user_key),
-        "w"  => kg.get_window_limit_key(user_key),
-        "t"  => kg.get_total_count_key(user_key),
-        _    => panic!("unknown suffix for absolute rate type: {suffix}"),
+        "h" => kg.get_hash_key(user_key),
+        "a" => kg.get_active_keys(user_key),
+        "w" => kg.get_window_limit_key(user_key),
+        "t" => kg.get_total_count_key(user_key),
+        _ => panic!("unknown suffix for absolute rate type: {suffix}"),
     }
 }
 
@@ -102,33 +102,21 @@ fn redis_state_after_single_allowed_inc() {
             .unwrap();
 
         // Total count must equal the incremented value.
-        let total: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
+        let total: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
         assert_eq!(total, 3, "total count should be 3");
 
         // Window limit must equal window_size * rate_limit = 10 * 5 = 50.
-        let window_limit: u64 = conn
-            .get(redis_key(&prefix, &k, "w"))
-            .await
-            .unwrap();
+        let window_limit: u64 = conn.get(redis_key(&prefix, &k, "w")).await.unwrap();
         assert_eq!(window_limit, 50, "window limit should be 50");
 
         // The hash must contain exactly one bucket whose value equals the increment.
-        let hash: HashMap<String, u64> = conn
-            .hgetall(redis_key(&prefix, &k, "h"))
-            .await
-            .unwrap();
+        let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
         assert_eq!(hash.len(), 1, "hash should have exactly one bucket");
         let bucket_count: u64 = *hash.values().next().unwrap();
         assert_eq!(bucket_count, 3, "bucket count should be 3");
 
         // The sorted set must contain exactly one member.
-        let active_count: u64 = conn
-            .zcard(redis_key(&prefix, &k, "a"))
-            .await
-            .unwrap();
+        let active_count: u64 = conn.zcard(redis_key(&prefix, &k, "a")).await.unwrap();
         assert_eq!(active_count, 1, "active sorted set should have one member");
 
         // The global active_entities sorted set must include the user key.
@@ -164,26 +152,17 @@ fn redis_state_coalesces_increments_within_rate_group() {
             .unwrap();
 
         // Total count must be 5.
-        let total: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
+        let total: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
         assert_eq!(total, 5, "total count should be 5");
 
         // Hash must have exactly one bucket (coalesced) with count = 5.
-        let hash: HashMap<String, u64> = conn
-            .hgetall(redis_key(&prefix, &k, "h"))
-            .await
-            .unwrap();
+        let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
         assert_eq!(hash.len(), 1, "coalesced — hash should have one bucket");
         let bucket_count: u64 = *hash.values().next().unwrap();
         assert_eq!(bucket_count, 5, "coalesced bucket should hold 5");
 
         // Active sorted set also has one member.
-        let active_count: u64 = conn
-            .zcard(redis_key(&prefix, &k, "a"))
-            .await
-            .unwrap();
+        let active_count: u64 = conn.zcard(redis_key(&prefix, &k, "a")).await.unwrap();
         assert_eq!(active_count, 1, "active sorted set should have one member");
     });
 }
@@ -211,24 +190,15 @@ fn redis_state_creates_distinct_buckets_across_rate_groups() {
             .unwrap();
 
         // Total count = 3.
-        let total: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
+        let total: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
         assert_eq!(total, 3);
 
         // Two separate buckets in the hash.
-        let hash: HashMap<String, u64> = conn
-            .hgetall(redis_key(&prefix, &k, "h"))
-            .await
-            .unwrap();
+        let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
         assert_eq!(hash.len(), 2, "two buckets should exist: {hash:?}");
 
         // Two entries in the active sorted set.
-        let active_count: u64 = conn
-            .zcard(redis_key(&prefix, &k, "a"))
-            .await
-            .unwrap();
+        let active_count: u64 = conn.zcard(redis_key(&prefix, &k, "a")).await.unwrap();
         assert_eq!(active_count, 2, "active sorted set should have two members");
     });
 }
@@ -254,33 +224,23 @@ fn redis_state_rejected_inc_does_not_mutate_state() {
             .await
             .unwrap();
 
-        let total_before: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
-        let hash_before: HashMap<String, u64> = conn
-            .hgetall(redis_key(&prefix, &k, "h"))
-            .await
-            .unwrap();
+        let total_before: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
+        let hash_before: HashMap<String, u64> =
+            conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
 
         // Attempt a rejected increment.
         let d = rl.redis().absolute().inc(&k, &rate_limit, 1).await.unwrap();
         assert!(matches!(d, RateLimitDecision::Rejected { .. }), "d: {d:?}");
 
-        let total_after: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
-        let hash_after: HashMap<String, u64> = conn
-            .hgetall(redis_key(&prefix, &k, "h"))
-            .await
-            .unwrap();
+        let total_after: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
+        let hash_after: HashMap<String, u64> =
+            conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
 
-        assert_eq!(total_before, total_after, "total count must not change on rejection");
         assert_eq!(
-            hash_before, hash_after,
-            "hash must not change on rejection"
+            total_before, total_after,
+            "total count must not change on rejection"
         );
+        assert_eq!(hash_before, hash_after, "hash must not change on rejection");
     });
 }
 
@@ -306,10 +266,7 @@ fn redis_state_evicts_expired_buckets_after_window() {
             .unwrap();
 
         // Confirm we are at capacity.
-        let total_before: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
+        let total_before: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
         assert_eq!(total_before, 3, "at capacity before expiry");
 
         // Wait past the 1-second window.
@@ -321,18 +278,9 @@ fn redis_state_evicts_expired_buckets_after_window() {
 
         // The evicted buckets must have been removed from both hash and sorted set,
         // and the total count must reflect only the new increment.
-        let hash: HashMap<String, u64> = conn
-            .hgetall(redis_key(&prefix, &k, "h"))
-            .await
-            .unwrap();
-        let total_after: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
-        let active_count: u64 = conn
-            .zcard(redis_key(&prefix, &k, "a"))
-            .await
-            .unwrap();
+        let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
+        let total_after: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
+        let active_count: u64 = conn.zcard(redis_key(&prefix, &k, "a")).await.unwrap();
 
         assert_eq!(
             total_after, 1,
@@ -401,10 +349,7 @@ fn redis_state_is_allowed_evicts_expired_buckets() {
             .unwrap();
 
         // Confirm state before expiry.
-        let total_before: u64 = conn
-            .get(redis_key(&prefix, &k, "t"))
-            .await
-            .unwrap();
+        let total_before: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
         assert_eq!(total_before, 2, "total should be 2 before expiry");
 
         // At capacity, `is_allowed` must reject immediately (before the window expires).
@@ -564,7 +509,10 @@ fn redis_state_active_entities_updated_on_inc() {
             .await
             .unwrap();
         let score_before: Option<f64> = conn.zscore(&ae_key, &**k).await.unwrap();
-        assert!(score_before.is_none(), "key should not be in active_entities before inc");
+        assert!(
+            score_before.is_none(),
+            "key should not be in active_entities before inc"
+        );
 
         rl.redis().absolute().inc(&k, &rate_limit, 1).await.unwrap();
 
@@ -596,10 +544,7 @@ fn redis_state_window_limit_key_has_ttl() {
             .await
             .unwrap();
 
-        let ttl: i64 = conn
-            .ttl(redis_key(&prefix, &k, "w"))
-            .await
-            .unwrap();
+        let ttl: i64 = conn.ttl(redis_key(&prefix, &k, "w")).await.unwrap();
 
         assert!(
             ttl > 0,

--- a/src/tests/test_redis_state_suppressed_redis_rate_limiter.rs
+++ b/src/tests/test_redis_state_suppressed_redis_rate_limiter.rs
@@ -20,8 +20,8 @@ use std::{collections::HashMap, thread, time::Duration};
 
 use redis::AsyncCommands;
 
+use super::common::{key, key_gen, redis_url, unique_prefix};
 use super::runtime;
-use super::common::{redis_url, unique_prefix, key, key_gen};
 
 use crate::common::{RateType, SuppressionFactorCacheMs};
 use crate::hybrid::SyncIntervalMs;
@@ -73,14 +73,14 @@ async fn build_limiter(
 fn redis_key(prefix: &RedisKey, user_key: &RedisKey, suffix: &str) -> String {
     let kg = key_gen(prefix, RateType::Suppressed);
     match suffix {
-        "h"  => kg.get_hash_key(user_key),
+        "h" => kg.get_hash_key(user_key),
         "hd" => kg.get_hash_declined_key(user_key),
-        "a"  => kg.get_active_keys(user_key),
-        "w"  => kg.get_window_limit_key(user_key),
-        "t"  => kg.get_total_count_key(user_key),
-        "d"  => kg.get_total_declined_key(user_key),
+        "a" => kg.get_active_keys(user_key),
+        "w" => kg.get_window_limit_key(user_key),
+        "t" => kg.get_total_count_key(user_key),
+        "d" => kg.get_total_declined_key(user_key),
         "sf" => kg.get_suppression_factor_key(user_key),
-        _    => panic!("unknown suffix for suppressed rate type: {suffix}"),
+        _ => panic!("unknown suffix for suppressed rate type: {suffix}"),
     }
 }
 
@@ -123,15 +123,11 @@ fn redis_state_suppressed_allowed_inc_sets_total_count_and_zero_declined() {
         assert_eq!(total, 3, "total count should be 3");
 
         // Declined count must be 0 (or the key may not exist).
-        let declined: u64 = conn
-            .get(redis_key(&prefix, &k, "d"))
-            .await
-            .unwrap_or(0u64);
+        let declined: u64 = conn.get(redis_key(&prefix, &k, "d")).await.unwrap_or(0u64);
         assert_eq!(declined, 0, "declined count should be 0");
 
         // The main hash must have the increment recorded.
-        let hash: HashMap<String, u64> =
-            conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
+        let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
         let hash_sum: u64 = hash.values().sum();
         assert_eq!(hash_sum, 3, "hash sum should equal the increment");
 
@@ -258,7 +254,10 @@ fn redis_state_suppressed_sf_cache_key_is_set_in_suppression_zone() {
             .unwrap();
 
         // Verify the return value directly — no separate Redis read needed here.
-        assert!(sf > 0.0, "suppression factor should be > 0 past the soft limit, got {sf}");
+        assert!(
+            sf > 0.0,
+            "suppression factor should be > 0 past the soft limit, got {sf}"
+        );
         assert!(
             (0.0..=1.0).contains(&sf),
             "suppression factor must be in [0, 1], got {sf}"
@@ -314,10 +313,7 @@ fn redis_state_suppressed_sf_cache_key_has_ttl() {
             .unwrap();
 
         // PTTL returns -2 (not found), -1 (no expiry), or positive ms.
-        let pttl: i64 = conn
-            .pttl(redis_key(&prefix, &k, "sf"))
-            .await
-            .unwrap();
+        let pttl: i64 = conn.pttl(redis_key(&prefix, &k, "sf")).await.unwrap();
 
         assert!(
             pttl > 0,
@@ -343,11 +339,16 @@ fn redis_state_suppressed_window_limit_key_equals_hard_limit() {
         // hard_window_limit = floor(5 * 4 * 3) = 60
         let expected_hard_limit = 60_u64;
 
-        let (rl, prefix) = build_limiter(&url, window_size_seconds, 1000, hard_limit_factor, 100).await;
+        let (rl, prefix) =
+            build_limiter(&url, window_size_seconds, 1000, hard_limit_factor, 100).await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(rate_limit_value).unwrap();
 
-        rl.redis().suppressed().inc(&k, &rate_limit, 1).await.unwrap();
+        rl.redis()
+            .suppressed()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
 
         let mut conn = redis::Client::open(url.as_str())
             .unwrap()
@@ -402,13 +403,9 @@ fn redis_state_suppressed_hash_sums_match_counter_keys() {
             .unwrap();
 
         let total: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
-        let declined: u64 = conn
-            .get(redis_key(&prefix, &k, "d"))
-            .await
-            .unwrap_or(0u64);
+        let declined: u64 = conn.get(redis_key(&prefix, &k, "d")).await.unwrap_or(0u64);
 
-        let hash: HashMap<String, u64> =
-            conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
+        let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
         let hash_d: HashMap<String, u64> =
             conn.hgetall(redis_key(&prefix, &k, "hd")).await.unwrap();
 
@@ -474,12 +471,8 @@ fn redis_state_suppressed_evicts_expired_buckets_from_both_hashes() {
             .unwrap();
 
         let total: u64 = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
-        let hash: HashMap<String, u64> =
-            conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
-        let active_count: u64 = conn
-            .zcard(redis_key(&prefix, &k, "a"))
-            .await
-            .unwrap();
+        let hash: HashMap<String, u64> = conn.hgetall(redis_key(&prefix, &k, "h")).await.unwrap();
+        let active_count: u64 = conn.zcard(redis_key(&prefix, &k, "a")).await.unwrap();
 
         // After eviction + one new increment, total must equal 1.
         assert_eq!(
@@ -523,18 +516,12 @@ fn redis_state_suppressed_get_factor_on_unknown_key_writes_no_state() {
 
         // None of the data keys should exist.
         let total: Option<u64> = conn.get(redis_key(&prefix, &k, "t")).await.unwrap();
-        let hash_len: u64 = conn
-            .hlen(redis_key(&prefix, &k, "h"))
-            .await
-            .unwrap();
+        let hash_len: u64 = conn.hlen(redis_key(&prefix, &k, "h")).await.unwrap();
         assert!(
             total.is_none(),
             "total count key should not exist for an unknown key"
         );
-        assert_eq!(
-            hash_len, 0,
-            "hash should be empty for an unknown key"
-        );
+        assert_eq!(hash_len, 0, "hash should be empty for an unknown key");
     });
 }
 
@@ -549,8 +536,16 @@ fn redis_state_suppressed_per_key_state_is_independent() {
         let b = key("b");
         let rate_limit = RateLimit::try_from(1f64).unwrap();
 
-        rl.redis().suppressed().inc(&a, &rate_limit, 4).await.unwrap();
-        rl.redis().suppressed().inc(&b, &rate_limit, 9).await.unwrap();
+        rl.redis()
+            .suppressed()
+            .inc(&a, &rate_limit, 4)
+            .await
+            .unwrap();
+        rl.redis()
+            .suppressed()
+            .inc(&b, &rate_limit, 9)
+            .await
+            .unwrap();
 
         let mut conn = redis::Client::open(url.as_str())
             .unwrap()
@@ -586,9 +581,16 @@ fn redis_state_suppressed_active_entities_updated_on_inc() {
 
         // Not present before any call.
         let score_before: Option<f64> = conn.zscore(&ae_key, &**k).await.unwrap();
-        assert!(score_before.is_none(), "key should not be in active_entities before inc");
+        assert!(
+            score_before.is_none(),
+            "key should not be in active_entities before inc"
+        );
 
-        rl.redis().suppressed().inc(&k, &rate_limit, 1).await.unwrap();
+        rl.redis()
+            .suppressed()
+            .inc(&k, &rate_limit, 1)
+            .await
+            .unwrap();
 
         let score_after: Option<f64> = conn.zscore(&ae_key, &**k).await.unwrap();
         assert!(

--- a/src/tests/test_redis_state_suppressed_redis_rate_limiter.rs
+++ b/src/tests/test_redis_state_suppressed_redis_rate_limiter.rs
@@ -220,8 +220,17 @@ fn redis_state_suppressed_sf_cache_key_is_set_in_suppression_zone() {
 
     runtime::block_on(async {
         // window=10s, rate=1, hard_limit_factor=2 => soft=10, hard=20.
-        // Use a tiny cache_ms so the key is always freshly computed.
-        let (rl, prefix) = build_limiter(&url, 10, 100, 2.0, 1).await;
+        //
+        // Use a cache_ms that is large enough for the `sf` key to survive the Redis
+        // round-trip that asserts its value, but short enough that we can wait for it
+        // to expire before calling `get_suppression_factor` so that function is forced
+        // to recompute (and therefore write) a fresh value.
+        //
+        // Previously this test used cache_ms=1, which created a race: `get_suppression_factor`
+        // wrote the `sf` key with a 1ms TTL, but by the time the assertion opened a new
+        // connection and issued GET the key had already expired, causing intermittent failures.
+        let cache_ms = 500_u64;
+        let (rl, prefix) = build_limiter(&url, 10, 100, 2.0, cache_ms).await;
         let k = key("k");
         let rate_limit = RateLimit::try_from(1f64).unwrap();
 
@@ -235,15 +244,28 @@ fn redis_state_suppressed_sf_cache_key_is_set_in_suppression_zone() {
                 .unwrap();
         }
 
-        // Let any cached suppression factor expire, then trigger a recompute.
-        runtime::async_sleep(Duration::from_millis(10)).await;
-        let _ = rl
+        // Wait for the `sf` key written by the inc loop to expire, so that the
+        // subsequent `get_suppression_factor` call is guaranteed to recompute and
+        // re-write the `sf` key with a fresh cache_ms TTL.
+        runtime::async_sleep(Duration::from_millis(cache_ms + 10)).await;
+
+        // Trigger a fresh computation. This writes `sf` with `cache_ms` TTL.
+        let sf = rl
             .redis()
             .suppressed()
             .get_suppression_factor(&k)
             .await
             .unwrap();
 
+        // Verify the return value directly — no separate Redis read needed here.
+        assert!(sf > 0.0, "suppression factor should be > 0 past the soft limit, got {sf}");
+        assert!(
+            (0.0..=1.0).contains(&sf),
+            "suppression factor must be in [0, 1], got {sf}"
+        );
+
+        // Also verify the `sf` key was physically written to Redis.  The key now has
+        // a full cache_ms TTL so there is no race with the assertion below.
         let mut conn = redis::Client::open(url.as_str())
             .unwrap()
             .get_multiplexed_async_connection()
@@ -256,12 +278,11 @@ fn redis_state_suppressed_sf_cache_key_is_set_in_suppression_zone() {
             "suppression factor cache key should be set when in the suppression zone"
         );
 
-        let sf: f64 = sf_raw.unwrap().parse().expect("sf should be a valid float");
+        let sf_stored: f64 = sf_raw.unwrap().parse().expect("sf should be a valid float");
         assert!(
-            (0.0..=1.0).contains(&sf),
-            "cached suppression factor must be in [0, 1], got {sf}"
+            (sf_stored - sf).abs() < 1e-9,
+            "stored sf value ({sf_stored}) should match the value returned by get_suppression_factor ({sf})"
         );
-        assert!(sf > 0.0, "suppression factor should be > 0 past the soft limit");
     });
 }
 

--- a/stress/src/local.rs
+++ b/stress/src/local.rs
@@ -56,12 +56,10 @@ impl BursterStore {
                 } else {
                     $map.insert(
                         key.to_owned(),
-                        std::sync::Mutex::new(
-                            burster::SlidingWindowLog::new_with_time_provider(
-                                capacity,
-                                burster_now as fn() -> Duration,
-                            ),
-                        ),
+                        std::sync::Mutex::new(burster::SlidingWindowLog::new_with_time_provider(
+                            capacity,
+                            burster_now as fn() -> Duration,
+                        )),
                     );
                     $map.get(key)
                         .unwrap()
@@ -179,7 +177,14 @@ fn run_trypema(args: &Args) {
 
     let elapsed = started.elapsed();
     let ops = total_ops.load(Ordering::Relaxed);
-    print_results(args, elapsed, ops, ops as f64 / elapsed.as_secs_f64(), &merged, &counts);
+    print_results(
+        args,
+        elapsed,
+        ops,
+        ops as f64 / elapsed.as_secs_f64(),
+        &merged,
+        &counts,
+    );
     print_error_stats(counts.errors.load(Ordering::Relaxed), &error_stats);
 }
 
@@ -202,7 +207,9 @@ fn run_burster(args: &Args) {
         }
     };
 
-    let capacity = (args.rate_limit_per_s * args.window_s as f64).max(1.0).round() as u64;
+    let capacity = (args.rate_limit_per_s * args.window_s as f64)
+        .max(1.0)
+        .round() as u64;
     let keys = crate::args::build_keys(args);
 
     let counts = Arc::new(Counts::default());
@@ -264,7 +271,14 @@ fn run_burster(args: &Args) {
     let elapsed = started.elapsed();
     let ops = total_ops.load(Ordering::Relaxed);
     println!("local_limiter=Burster burster_capacity_per_window={capacity}");
-    print_results(args, elapsed, ops, ops as f64 / elapsed.as_secs_f64(), &merged, &counts);
+    print_results(
+        args,
+        elapsed,
+        ops,
+        ops as f64 / elapsed.as_secs_f64(),
+        &merged,
+        &counts,
+    );
     print_error_stats(counts.errors.load(Ordering::Relaxed), &error_stats);
 }
 
@@ -276,13 +290,14 @@ fn run_governor(args: &Args) {
     // governor also uses extra stack space with many keys.
     const STACK_SIZE: usize = 16 * 1024 * 1024;
 
-    let rate_u32 = u32::try_from(
-        (args.rate_limit_per_s.max(1.0).round() as u64).min(u32::MAX as u64),
-    )
-    .unwrap_or(u32::MAX);
+    let rate_u32 =
+        u32::try_from((args.rate_limit_per_s.max(1.0).round() as u64).min(u32::MAX as u64))
+            .unwrap_or(u32::MAX);
 
     let burst_u32 = u32::try_from(
-        ((args.rate_limit_per_s * args.window_s as f64).max(1.0).round() as u64)
+        ((args.rate_limit_per_s * args.window_s as f64)
+            .max(1.0)
+            .round() as u64)
             .min(u32::MAX as u64),
     )
     .unwrap_or(u32::MAX)
@@ -290,8 +305,7 @@ fn run_governor(args: &Args) {
 
     let quota = Quota::per_second(std::num::NonZeroU32::new(rate_u32).unwrap())
         .allow_burst(std::num::NonZeroU32::new(burst_u32).unwrap());
-    let rl: Arc<DefaultKeyedRateLimiter<String>> =
-        Arc::new(governor::RateLimiter::keyed(quota));
+    let rl: Arc<DefaultKeyedRateLimiter<String>> = Arc::new(governor::RateLimiter::keyed(quota));
 
     let capacity = burst_u32 as u64;
     let keys = crate::args::build_keys(args);
@@ -355,7 +369,14 @@ fn run_governor(args: &Args) {
     let elapsed = started.elapsed();
     let ops = total_ops.load(Ordering::Relaxed);
     println!("local_limiter=Governor governor_capacity_per_window={capacity}");
-    print_results(args, elapsed, ops, ops as f64 / elapsed.as_secs_f64(), &merged, &counts);
+    print_results(
+        args,
+        elapsed,
+        ops,
+        ops as f64 / elapsed.as_secs_f64(),
+        &merged,
+        &counts,
+    );
     print_error_stats(counts.errors.load(Ordering::Relaxed), &error_stats);
 }
 

--- a/stress/src/redis.rs
+++ b/stress/src/redis.rs
@@ -184,7 +184,9 @@ async fn run_async(args: Args) {
                             Ok(decision) => wl.record_decision(decision),
                             Err(err) => wl.record_error(
                                 err.to_string(),
-                                Some(format!("provider=redis limiter=trypema key={k:?} err={err:?}")),
+                                Some(format!(
+                                    "provider=redis limiter=trypema key={k:?} err={err:?}"
+                                )),
                             ),
                         }
                     }
@@ -253,7 +255,14 @@ async fn run_async(args: Args) {
     let elapsed = started.elapsed();
     let ops = total_ops.load(Ordering::Relaxed);
     println!("redis_limiter={:?}", args.redis_limiter);
-    print_results(&args, elapsed, ops, ops as f64 / elapsed.as_secs_f64(), &merged, &counts);
+    print_results(
+        &args,
+        elapsed,
+        ops,
+        ops as f64 / elapsed.as_secs_f64(),
+        &merged,
+        &counts,
+    );
     print_error_stats(counts.errors.load(Ordering::Relaxed), &error_stats);
 }
 

--- a/stress/src/runner.rs
+++ b/stress/src/runner.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
     Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
 };
 use std::time::{Duration, Instant};
 

--- a/stress/src/runtime.rs
+++ b/stress/src/runtime.rs
@@ -69,5 +69,3 @@ pub(crate) fn block_on<F: std::future::Future>(f: F) -> F::Output {
 pub(crate) fn block_on<F: std::future::Future>(f: F) -> F::Output {
     smol::block_on(f)
 }
-
-


### PR DESCRIPTION
# Changelog

## `ft/v1.1.0` - Unreleased

Branch summary for changes since `v1.0.1`.

### Added

- Added `RateLimiterBuilder` and related builder tests for configuring a `RateLimiter` more ergonomically.
- Added public helper methods across the rate limiter APIs to make common usage and inspection flows easier to discover.
- Added `docs/conventions.md` to capture the repository's documentation conventions for future updates.
- Added runtime-agnostic doctest helpers so Redis and hybrid documentation examples can run without exposing Tokio- or Smol-specific setup in user-facing snippets.

### Changed

- Refreshed the public documentation in `README.md`, `docs/lib.md`, and key API docs to be shorter, more focused, and example-driven.
- Expanded docs for common public types such as `RateLimit`, `RedisKey`, provider options, and builder/setup APIs.
- Updated installation snippets to use `trypema = "1"` instead of `trypema = "1.0"`.
- Standardized Redis documentation around Redis `7.2+`.
- Improved builder/setup guidance to clearly distinguish:
  - local-only usage without Redis features
  - Redis-enabled usage with `redis-tokio` or `redis-smol`
  - automatic cleanup startup via `build()` versus manual startup via `run_cleanup_loop()`

### Fixed

- Fixed flaky Redis-related tests and state-handling behavior.
- Fixed Redis and hybrid doctest failures caused by runtime/connection lifetime issues that previously surfaced as broken-pipe errors.
- Fixed absolute hybrid Redis reads so entities are marked active on read, improving consistency with cleanup/state tracking behavior.

### Validation

- Added coverage for the new builder behavior.
- Reworked documentation examples so the shown examples are aligned with doctest execution.
- Verified doc rendering and doctests across local-only, `redis-tokio`, and `redis-smol` configurations during this branch's documentation update work.
